### PR TITLE
Switch pretrained transformer to albert

### DIFF
--- a/t2t.jsonnet
+++ b/t2t.jsonnet
@@ -8,7 +8,7 @@
 // serialized transformer model. Note, to avoid issues, please name the serialized model folder in
 // the same format as the Transformers library, e.g.
 // [bert|roberta|gpt2|distillbert|etc]-[base|large|etc]-[uncased|cased|etc]
-local pretrained_transformer_model_name = "bert-base-uncased";
+local pretrained_transformer_model_name = "albert-base-v1";
 // This will be used to set the max # of source tokens and the max # of decoding steps
 local max_sequence_length = 512;
 // This corresponds to the config.hidden_size of the pretrained_transformer_model_name


### PR DESCRIPTION
# Overview

After testing three pre-trained transformers as encoder (BERT, RoBERTa, ALBERT), ALBERT appears to be learning the most distinct clusters.

![image](https://user-images.githubusercontent.com/8917831/70380194-44525a00-1905-11ea-91de-3d426af605e7.png)

This PR simply updates the config to use ALBERT by default. Note that we are currently using the base V1 model because the V2 model appears to have some issues. Wait for the V2 model issues to be addressed in Transformer library before switching.

## Closes

Closes #13.
