### PR TITLE
Add weight-decay to config

### DIFF
--- a/t2t.jsonnet
+++ b/t2t.jsonnet
@@ -105,19 +105,23 @@ local do_lowercase = true;
         "type": "bucket",
         "sorting_keys": [["source_tokens", "num_tokens"]],
         // TODO (John): Ideally this would be [16, 32], but there are OOM issues
-        "batch_size": 8
+        "batch_size": 6
     },
     "validation_iterator": {
         "type": "bucket",
         "sorting_keys": [["source_tokens", "num_tokens"]],
-        "batch_size": 32
+        "batch_size": 16
     },
     "trainer": {
         "optimizer": {
-            "type": "adam",
+            "type": "huggingface_adamw",
             // TODO (John): Because our decoder is trained from scratch, we will likely need a larger
             // learning rate. Idea: different learning rates for encoder / decoder?
-            "lr": 5e-5
+            "lr": 5e-5,
+            "weight_decay": 0.01,
+            "parameter_groups": [
+              [["bias", "LayerNorm.bias", "LayerNorm.weight", "layer_norm.weight"], {"weight_decay": 0.0}],
+            ],
         },
         "patience": 5,
         "validation_metric": "+BLEU",


### PR DESCRIPTION
# Overview

This is a small PR that updates the optimizer to the `AdamW` implementation provided by HuggingFace's Transformers library (from the `Adam` implementation in PyTorch). It also adds weight decay (excluding the weights and biases of layer norm).

I didn't bother checking the impact on our model performance - every fine-tuning setup of BERT/RoBERTa/ALBERT I have seen uses weight decay in this fashion -- likely to prevent large updates to the models pre-trained weights.

The optimizer of our fine-tuning procedure now matches the examples given in the Transformers library. In the future, we will need to tune the weight decay hyperparameter.

