### PR TITLE
Add grad accumulation for batch size of 16

### DIFF
--- a/t2t.jsonnet
+++ b/t2t.jsonnet
@@ -105,7 +105,7 @@ local do_lowercase = true;
         "type": "bucket",
         "sorting_keys": [["source_tokens", "num_tokens"]],
         // TODO (John): Ideally this would be [16, 32], but there are OOM issues
-        "batch_size": 6
+        "batch_size": 4
     },
     "validation_iterator": {
         "type": "bucket",
@@ -120,7 +120,9 @@ local do_lowercase = true;
             "lr": 5e-5,
             "weight_decay": 0.01,
             "parameter_groups": [
-              [["bias", "LayerNorm.bias", "LayerNorm.weight", "layer_norm.weight"], {"weight_decay": 0.0}],
+              [
+                  ["bias", "LayerNorm.bias", "LayerNorm.weight", "layer_norm.weight", "decoder"],
+                  {"weight_decay": 0.0}],
             ],
         },
         "patience": 5,
@@ -128,6 +130,8 @@ local do_lowercase = true;
         "num_epochs": 25,
         "num_serialized_models_to_keep": 1,
         "cuda_device": 0,
-        "grad_norm": 1.0
+        "grad_norm": 1.0,
+        // The effective batch size is batch_size * num_gradient_accumulation_steps
+        "num_gradient_accumulation_steps": 4
     }
 }


### PR DESCRIPTION
# Overview

This PR simply adds grad accumulation by providing the argument in the config. With gradient accumulation, we can get an effective batch size of 16 or 32, which is the batch size used for nearly every fine-tuning task I have seen with BERT/ALBERT/RoBERTa models.

This should give us a (small) reduction in training times, as we will end up performing `num_gradient_accumulation_steps` times less backward passes (I didn't benchmark this).

## Other changes

Weight decay was erroneously applied to the weights of the decoder. I don't believe this is necessary as these weights are trained from scratch and there is little risk of overfitting given the size of our datasets and difficulty of the task (wishful thinking maybe). This PR adds the weights of the decoder to the parameter group with no weight decay.