### PR TITLE
Dont save embeddings when training

### DIFF
--- a/t2t/models/encoder_decoders/composed_seq2seq_with_doc_embeddings.py
+++ b/t2t/models/encoder_decoders/composed_seq2seq_with_doc_embeddings.py
@@ -10,9 +10,9 @@ from allennlp.models.model import Model
 @Model.register("composed_seq2seq_with_doc_embeddings")
 class ComposedSeq2SeqWithDocEmbeddings(ComposedSeq2Seq):
     """
-    A thin wrapper around ``ComposedSeq2Seq`` which adds the document embeddings learned by the
-    model to its ``output_dict`` in the ``forward`` hook. See the ``ComposedSeq2Seq model in the
-    AllenNLP documentation for full details.
+    A thin wrapper around ``ComposedSeq2Seq`` which adds the document embeddings learned by the model to its
+    ``output_dict`` in the ``forward`` hook. See the ``ComposedSeq2Seq`` model in the AllenNLP documentation for
+    full details.
     """
 
     @overrides
@@ -28,11 +28,11 @@ class ComposedSeq2SeqWithDocEmbeddings(ComposedSeq2Seq):
         Parameters
         ----------
         source_tokens : ``Dict[str, torch.LongTensor]``
-           The output of `TextField.as_array()` applied on the source `TextField`. This will be
-           passed through a `TextFieldEmbedder` and then through an encoder.
+           The output of `TextField.as_array()` applied on the source `TextField`. This will be passed through a
+           `TextFieldEmbedder` and then through an encoder.
         target_tokens : ``Dict[str, torch.LongTensor]``, optional (default = None)
-           Output of `Textfield.as_array()` applied on target `TextField`. We assume that the
-           target tokens are also represented as a `TextField`.
+           Output of `Textfield.as_array()` applied on target `TextField`. We assume that the target tokens are
+           also represented as a `TextField`.
 
         Returns
         -------
@@ -45,7 +45,6 @@ class ComposedSeq2SeqWithDocEmbeddings(ComposedSeq2Seq):
         # During eval, copy the encoders output to CPU memory. This becomes our document embedding.
         # HACK (John): Document embeddings are expanded along the second dimension, drop it
         if not self.training:
-            output_dict['doc_embeddings'] = \
-                state['encoder_outputs'][:, 0, :].cpu().squeeze(1)
+            output_dict['doc_embeddings'] = state['encoder_outputs'][:, 0, :].cpu().squeeze(1)
 
         return output_dict


### PR DESCRIPTION
# Overview

Previously, we were saving a copy of the encoders output states while training. This PR does two things:

1. Document embeddings will not be added to the `output_dict` if we are training.
2. Rather than making a copy of the document embeddings on the GPU, copy them to the CPU memory. This should reduce overall memory consumption without any impact on speed (as we don't perform any computation on the document embeddings).