### PR TITLE
drop lazy, add kwargs

### DIFF
--- a/t2t/data/dataset_readers/seq2sameseq.py
+++ b/t2t/data/dataset_readers/seq2sameseq.py
@@ -33,12 +33,12 @@ class Seq2SameSeqDatasetReader(Seq2SeqDatasetReader):
         delimiter: str = None,
         source_max_tokens: Optional[int] = None,
         target_max_tokens: Optional[int] = None,
-        lazy: bool = False,
+        **kwargs,
     ) -> None:
         super().__init__(
             source_tokenizer, target_tokenizer, source_token_indexers, target_token_indexers,
             source_add_start_token, source_add_end_token, delimiter, source_max_tokens,
-            target_max_tokens, lazy
+            target_max_tokens, **kwargs
         )
 
     @overrides


### PR DESCRIPTION
# Overview

AllenNLP appears to have dropped the argument `lazy` from the constructor of their `DatasetReader` subclasses. This lead to an error for our class `Seq2SameSeqDatasetReader` which subclasses `Seq2SeqDatasetReader`.

This is just a quick PR that copies the `Seq2SeqDatasetReader` constructor arguments to `Seq2SameSeqDatasetReader`.

```python
@DatasetReader.register("seq2sameseq")
class Seq2SameSeqDatasetReader(Seq2SeqDatasetReader):
    """
    A thin wrapper around ``Seq2SeqDatasetReader`` that is expected to be used with an
    encoder-decoder that is trained to reconstruct the source sequence. Each line in the input file
    should contain a sequence string. Please see ``Seq2SeqDatasetReader`` for usage instructions and
    parameters.
    """

    def __init__(
        self,
        source_tokenizer: Tokenizer = None,
        target_tokenizer: Tokenizer = None,
        source_token_indexers: Dict[str, TokenIndexer] = None,
        target_token_indexers: Dict[str, TokenIndexer] = None,
        source_add_start_token: bool = True,
        source_add_end_token: bool = True,
        delimiter: str = None,
        source_max_tokens: Optional[int] = None,
        target_max_tokens: Optional[int] = None,
        **kwargs,
```