### PR TITLE
Set `num_workers` to 1

### DIFF
--- a/training_config/contrastive_only.jsonnet
+++ b/training_config/contrastive_only.jsonnet
@@ -47,6 +47,7 @@ local min_length = 32;
     },
     "data_loader": {
         "batch_size": 4,
+        "num_workers": 1,
         "drop_last": true,
     },
     "trainer": {

--- a/training_config/declutr.jsonnet
+++ b/training_config/declutr.jsonnet
@@ -47,6 +47,7 @@ local min_length = 32;
     },
     "data_loader": {
         "batch_size": 4,
+        "num_workers": 1,
         "drop_last": true,
     },
     "trainer": {

--- a/training_config/declutr_base.jsonnet
+++ b/training_config/declutr_base.jsonnet
@@ -1,0 +1,77 @@
+// This should be a registered name in the Transformers library (see https://huggingface.co/models) 
+// OR a path on disk to a serialized transformer model.
+local transformer_model = "roberta-base";
+
+// This will be used to set the max/min # of tokens in the positive and negative examples.
+local max_length = 512;
+local min_length = 32;
+
+{
+    "dataset_reader": {
+        "type": "declutr",
+        "lazy": true,
+        "num_anchors": 2,
+        "num_positives": 2,
+        "max_span_len": max_length,
+        "min_span_len": min_length,
+        "tokenizer": {
+            "type": "pretrained_transformer",
+            "model_name": transformer_model,
+            // Account for special tokens (e.g. CLS and SEP), otherwise a cryptic error is thrown.
+            "max_length": max_length - 2,
+        },
+        "token_indexers": {
+            "tokens": {
+                "type": "pretrained_transformer",
+                "model_name": transformer_model,
+            },
+        },
+    }, 
+    "train_data_path": null,
+    "model": {
+        "type": "declutr",
+        "text_field_embedder": {
+            "type": "mlm",
+            "token_embedders": {
+                "tokens": {
+                    "type": "pretrained_transformer_mlm",
+                    "model_name": transformer_model,
+                    "masked_language_modeling": true
+                },
+            },
+        },
+        "loss": {
+            "type": "nt_xent",
+            "temperature": 0.05,
+        },
+    },
+    "data_loader": {
+        "batch_size": 4,
+        "num_workers": 1,
+        "drop_last": true,
+    },
+    "trainer": {
+        // If Apex is installed, chose one of its opt_levels here to use mixed-precision training.
+        "opt_level": null,
+        "optimizer": {
+            "type": "huggingface_adamw",
+            "lr": 5e-5,
+            "weight_decay": 0.0,
+            "parameter_groups": [
+                // Apply weight decay to pre-trained params, excluding LayerNorm params and biases
+                // See: https://github.com/huggingface/transformers/blob/2184f87003c18ad8a172ecab9a821626522cf8e7/examples/run_ner.py#L105
+                // Regex: https://regex101.com/r/ZUyDgR/3/tests
+                [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.1}],
+            ],
+        },
+        "num_epochs": 1,
+        "checkpointer": {
+            // A value of null or -1 will save the weights of the model at the end of every epoch
+            "num_serialized_models_to_keep": -1,
+        },
+        "grad_norm": 1.0,
+        "learning_rate_scheduler": {
+            "type": "slanted_triangular",
+        },
+    },
+}

--- a/training_config/declutr_small.jsonnet
+++ b/training_config/declutr_small.jsonnet
@@ -47,6 +47,7 @@ local min_length = 32;
     },
     "data_loader": {
         "batch_size": 4,
+        "num_workers": 1,
         "drop_last": true,
     },
     "trainer": {

--- a/training_config/mlm_only.jsonnet
+++ b/training_config/mlm_only.jsonnet
@@ -46,6 +46,7 @@ local min_length = 32;
     },
     "data_loader": {
         "batch_size": 4,
+        "num_workers": 1,
         "drop_last": true,
     },
     "trainer": {

--- a/training_config/transformer_cls.jsonnet
+++ b/training_config/transformer_cls.jsonnet
@@ -48,6 +48,7 @@ local cls_is_last_token = false;
     },
     "data_loader": {
         "batch_size": 16,
+        "num_workers": 1,
         "drop_last": true,
     },
     "trainer": {

--- a/training_config/transformer_mean.jsonnet
+++ b/training_config/transformer_mean.jsonnet
@@ -38,6 +38,7 @@ local max_length = 512;
     },
     "data_loader": {
         "batch_size": 16,
+        "num_workers": 1,
         "drop_last": true,
     },
     "trainer": {


### PR DESCRIPTION
# Overview

In a previous PR, I remove `num_workers=1` from the config because I thought it was responsible for a bug, but it turns out its not. Futhermore, the model trains almost 4X faster when `num_workers=1`, so I am adding this back in.

## Other changes

- :wrench: Add a DeCLUTR-base config