### PR TITLE
Fix sorting bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you want to train with [mixed-precision](https://devblogs.nvidia.com/mixed-pr
 You can embed text with a trained model in one of three ways:
 
 1. [As a library](#as-a-library): import and initialize an object from this repo, which can be used to embed sentences/paragraphs.
-2. [🤗 Transformers](#🤗-transformers): load our pretrained model with the [🤗 transformers library](https://github.com/huggingface/transformers).
+2. [🤗 Transformers](#🤗-transformers): load our pretrained model with the [🤗 Transformers library](https://github.com/huggingface/transformers).
 3. [Bulk embed](#bulk-embed-a-file): embed all text in a given text file with a simple command-line interface.
 
 #### As a library

--- a/declutr/encoder.py
+++ b/declutr/encoder.py
@@ -78,7 +78,8 @@ class Encoder:
             # In the future, it would be better to use the built-in bucket sort of AllenNLP,
             # which would lead to an even larger speedup.
             unsort = True
-            unsorted_indices, inputs = zip(*sorted(enumerate(inputs), key=itemgetter(1)))
+            sorted_indices, inputs = zip(*sorted(enumerate(inputs), key=itemgetter(1)))
+            unsorted_indices, _ = zip(*sorted(enumerate(sorted_indices), key=itemgetter(1)))
 
         json_formatted_inputs = [{"text": input_} for input_ in inputs]
 


### PR DESCRIPTION
# Overview

There was a silly bug in Encoder that would have lead to incorrect ordering of embeddings. This has now been fixed. I should really write some unit tests for this (#121).