### PR TITLE
Revert to old optimizer hyperparams

### DIFF
--- a/tests/common/test_model_utils.py
+++ b/tests/common/test_model_utils.py
@@ -1,14 +1,15 @@
 from copy import deepcopy
 
 import torch
-from hypothesis import given
+from allennlp.data import TextFieldTensors
+from hypothesis import given, settings
 from hypothesis.strategies import integers
 
-from allennlp.data import TextFieldTensors
 from declutr.common.model_utils import unpack_batch
 
 
 class TestModelUtils:
+    @settings(deadline=None)
     @given(
         batch_size=integers(min_value=1, max_value=4),
         num_anchors=integers(min_value=1, max_value=4),

--- a/training_config/contrastive_only.jsonnet
+++ b/training_config/contrastive_only.jsonnet
@@ -56,6 +56,8 @@ local min_length = 32;
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,
+            "eps": 1e-06,
+            "correct_bias": false,
             "weight_decay": 0.0,
             "parameter_groups": [
                 # Apply weight decay to pre-trained params, excluding LayerNorm params and biases

--- a/training_config/declutr.jsonnet
+++ b/training_config/declutr.jsonnet
@@ -56,6 +56,8 @@ local min_length = 32;
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,
+            "eps": 1e-06,
+            "correct_bias": false,
             "weight_decay": 0.0,
             "parameter_groups": [
                 // Apply weight decay to pre-trained params, excluding LayerNorm params and biases

--- a/training_config/declutr_base.jsonnet
+++ b/training_config/declutr_base.jsonnet
@@ -56,6 +56,8 @@ local min_length = 32;
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,
+            "eps": 1e-06,
+            "correct_bias": false,
             "weight_decay": 0.0,
             "parameter_groups": [
                 // Apply weight decay to pre-trained params, excluding LayerNorm params and biases

--- a/training_config/declutr_small.jsonnet
+++ b/training_config/declutr_small.jsonnet
@@ -56,6 +56,8 @@ local min_length = 32;
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,
+            "eps": 1e-06,
+            "correct_bias": false,
             "weight_decay": 0.0,
             "parameter_groups": [
                 // Apply weight decay to pre-trained params, excluding LayerNorm params and biases

--- a/training_config/mlm_only.jsonnet
+++ b/training_config/mlm_only.jsonnet
@@ -55,6 +55,8 @@ local min_length = 32;
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,
+            "eps": 1e-06,
+            "correct_bias": false,
             "weight_decay": 0.0,
             "parameter_groups": [
                 # Apply weight decay to pre-trained params, excluding LayerNorm params and biases


### PR DESCRIPTION
# Overview

Reverts the `eps` and `correct_bias` hyperparams back to their values _before_ AllenNLP 1.0.0. changed their defaults. I confirmed these params produce scores nearly identical to those in our paper.

## Closes

Closes #124.