### PR TITLE
Support scalar mix

### DIFF
--- a/declutr/common/contrastive_utils.py
+++ b/declutr/common/contrastive_utils.py
@@ -48,9 +48,10 @@ def sample_anchor_positive_pairs(
     # Several checks on the parameters passed to this function. The first check on length is mostly
     # arbitrary, but it prevents the Hypothesis tests from breaking. And it makes little sense to
     # sample from extremely short documents.
-    if num_tokens < 10:
+    if num_tokens < num_anchors * max_span_len * 2:
         raise ValueError(
-            (f"len({tok_method}) should be at least 10 (ideally much longer), got {num_tokens}.")
+            f"len({tok_method}) should be at least {num_anchors * max_span_len * 2}"
+            f" (num_anchors * max_span_len * 2), got {num_tokens}."
         )
     if min_span_len > max_span_len:
         raise ValueError(

--- a/declutr/common/contrastive_utils.py
+++ b/declutr/common/contrastive_utils.py
@@ -45,9 +45,6 @@ def sample_anchor_positive_pairs(
     tok_method = "tokenizer(text)" if tokenizer else "text.split()"
     num_tokens = len(tokens)
 
-    # Several checks on the parameters passed to this function. The first check on length is mostly
-    # arbitrary, but it prevents the Hypothesis tests from breaking. And it makes little sense to
-    # sample from extremely short documents.
     if num_tokens < num_anchors * max_span_len * 2:
         raise ValueError(
             f"len({tok_method}) should be at least {num_anchors * max_span_len * 2}"
@@ -68,22 +65,24 @@ def sample_anchor_positive_pairs(
     # Valid anchor starts are token indices which begin a token span of at least max_span_len.
     anchors, positives = [], []
     valid_anchor_starts = list(range(0, num_tokens - max_span_len + 1, max_span_len))
-    for _ in range(num_anchors):
+    for i in range(num_anchors):
         # Sample the anchor length from a beta distribution skewed towards longer spans, the
         # intuition being that longer spans have the best chance of being representative of the
         # document they are sampled from.
         anchor_len = int(np.random.beta(4, 2) * (max_span_len - min_span_len) + min_span_len)
-        # Sample an anchor start position from the list of valid positions. Once sampled, remove it
-        # (and its immediate neighbours) from consideration.
-        anchor_start_idx = np.random.randint(len(valid_anchor_starts))
+        # This check prevents an edge case were we run out of valid_anchor_starts.
+        if len(valid_anchor_starts) // (num_anchors - i) < num_anchors - i:
+            anchor_start_idx = np.random.choice([0, len(valid_anchor_starts) - 1])
+        else:
+            anchor_start_idx = np.random.randint(len(valid_anchor_starts))
         # When num_anchors = 1, this is equivalent to uniformly sampling that starting position.
         anchor_start = np.random.randint(
             valid_anchor_starts[anchor_start_idx],
             # randint is high-exclusive
             valid_anchor_starts[anchor_start_idx] + max_span_len - anchor_len + 1,
         )
+        # Once sampled, remove an anchor (and its immediate neighbours) from consideration.
         del valid_anchor_starts[max(0, anchor_start_idx - 1) : anchor_start_idx + 2]
-        # Grab the anchor with its sampled start and length.
         anchor_end = anchor_start + anchor_len
         anchors.append(" ".join(tokens[anchor_start:anchor_end]))
 

--- a/declutr/encoder.py
+++ b/declutr/encoder.py
@@ -1,3 +1,4 @@
+import warnings
 from operator import itemgetter
 from typing import List, Optional, Union
 
@@ -96,8 +97,14 @@ class Encoder:
             )
             embeddings = torch.index_select(embeddings, dim=0, index=unsorted_indices)
         if self._sphereize:
-            centroid = torch.mean(embeddings, dim=0)
-            embeddings -= centroid
-            embeddings /= torch.norm(embeddings, dim=1, keepdim=True)
+            if embeddings.size(0) > 1:
+                centroid = torch.mean(embeddings, dim=0)
+                embeddings -= centroid
+                embeddings /= torch.norm(embeddings, dim=1, keepdim=True)
+            else:
+                warnings.warn(
+                    "sphereize==True but only a single input sentence was passed."
+                    " Inputs will not be sphereized."
+                )
 
         return embeddings.numpy()

--- a/declutr/losses/pytorch_metric_learning.py
+++ b/declutr/losses/pytorch_metric_learning.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Tuple
 
 import torch
@@ -43,7 +44,11 @@ class PyTorchMetricLearningLoss(Registrable):
         loss function.
         """
         embeddings = torch.cat((anchors, positives))
-        indices = torch.arange(0, anchors.size(0), device=anchors.device)
+        # When using CrossBatchMemory, labels persist across batches so they need to be unique.
+        # By choosing a random integer in (0, sys.maxsize) we can be reasonably sure of this.
+        # Obviously, there are better (i.e. deterministic ways to do this), but I don't have
+        # access to the current batch id or some other uniquely identifying value.
+        indices = torch.randint(sys.maxsize, (anchors.size(0),), device=anchors.device)
         labels = torch.cat((indices, indices))
 
         return embeddings, labels

--- a/tests/common/test_contrastive_utils.py
+++ b/tests/common/test_contrastive_utils.py
@@ -1,37 +1,49 @@
-from random import randint
-from typing import Union
+import random
+from typing import List, Union
 
 import pytest
 from hypothesis import given
-from hypothesis.strategies import integers, sampled_from, text
+from hypothesis.strategies import integers, sampled_from
 
 from declutr.common.contrastive_utils import sample_anchor_positive_pairs
 
 
 class TestContrastiveUtils:
-    def tokenize(self, text):
+    def tokenize(self, text) -> List[str]:
         return text.split()
 
     @given(
-        text=text(),
         num_anchors=integers(min_value=1, max_value=4),
         num_positives=integers(min_value=1, max_value=4),
         sampling_strategy=sampled_from(["subsuming", "adjacent", None]),
     )
     def test_sample_spans(
-        self, text: str, num_anchors: int, num_positives: int, sampling_strategy: Union[str, None]
-    ):
-        tokens = self.tokenize(text)
-        num_tokens = len(tokens)
-        # These represent sensible defaults
-        max_span_len = num_tokens // 2
-        min_span_len = randint(1, num_tokens // 2) if num_tokens // 2 > 1 else 1
+        self,
+        inputs: List[str],
+        num_anchors: int,
+        num_positives: int,
+        sampling_strategy: Union[str, None],
+    ) -> None:
 
-        # The sampling procedure often breaks if we don't have at least ten tokens, so we set
-        # a strict lower bound.
-        if num_tokens < 10:
-            with pytest.raises(ValueError):
-                _, _ = sample_anchor_positive_pairs(
+        for text in inputs:
+            tokens = self.tokenize(text)
+            num_tokens = len(tokens)
+            # These represent sensible defaults
+            max_span_len = num_tokens // 4
+            min_span_len = random.randint(1, max_span_len) if max_span_len > 1 else 1
+
+            if num_tokens < num_anchors * max_span_len * 2:
+                with pytest.raises(ValueError):
+                    _, _ = sample_anchor_positive_pairs(
+                        text,
+                        num_anchors=num_anchors,
+                        num_positives=num_positives,
+                        max_span_len=max_span_len,
+                        min_span_len=min_span_len,
+                        sampling_strategy=sampling_strategy,
+                    )
+            else:
+                anchors, positives = sample_anchor_positive_pairs(
                     text,
                     num_anchors=num_anchors,
                     num_positives=num_positives,
@@ -39,40 +51,31 @@ class TestContrastiveUtils:
                     min_span_len=min_span_len,
                     sampling_strategy=sampling_strategy,
                 )
-        else:
-            anchors, positives = sample_anchor_positive_pairs(
-                text,
-                num_anchors=num_anchors,
-                num_positives=num_positives,
-                max_span_len=max_span_len,
-                min_span_len=min_span_len,
-                sampling_strategy=sampling_strategy,
-            )
-            assert len(anchors) == num_anchors
-            assert len(positives) == num_positives
-            for i, anchor in enumerate(anchors):
-                # Several simple checks for valid anchors.
-                anchor_tokens = self.tokenize(anchor)
-                anchor_length = len(anchor_tokens)
-                assert anchor_length <= max_span_len
-                assert anchor_length >= min_span_len
-                # The tokenization process may lead to certain characters (such as escape
-                # characters) being dropped, so repeat the tokenization process before performing
-                # this check (otherwise a bunch of tests fail).
-                assert anchor in " ".join(tokens)
-                for j in range(i, i + num_positives):
-                    # Several simple checks for valid positives.
-                    positive = positives[j]
-                    positive_tokens = self.tokenize(positive)
-                    positive_length = len(positive_tokens)
-                    assert positive_length <= max_span_len
-                    assert positive_length >= min_span_len
-                    assert positive in " ".join(tokens)
-                    # Test that specific sampling strategies are obeyed.
-                    if sampling_strategy == "subsuming":
-                        assert positive in " ".join(anchor_tokens)
-                    elif sampling_strategy == "adjacent":
-                        assert positive not in " ".join(anchor_tokens)
+                assert len(anchors) == num_anchors
+                assert len(positives) == num_anchors * num_positives
+                for i, anchor in enumerate(anchors):
+                    # Several simple checks for valid anchors.
+                    anchor_tokens = self.tokenize(anchor)
+                    anchor_length = len(anchor_tokens)
+                    assert anchor_length <= max_span_len
+                    assert anchor_length >= min_span_len
+                    # The tokenization process may lead to certain characters (such as escape
+                    # characters) being dropped, so repeat the tokenization process before
+                    # performing this check (otherwise a bunch of tests fail).
+                    assert anchor in " ".join(tokens)
+                    for j in range(i * num_positives, i * num_positives + num_positives):
+                        # Several simple checks for valid positives.
+                        positive = positives[j]
+                        positive_tokens = self.tokenize(positive)
+                        positive_length = len(positive_tokens)
+                        assert positive_length <= max_span_len
+                        assert positive_length >= min_span_len
+                        assert positive in " ".join(tokens)
+                        # Test that specific sampling strategies are obeyed.
+                        if sampling_strategy == "subsuming":
+                            assert positive in " ".join(anchor_tokens)
+                        elif sampling_strategy == "adjacent":
+                            assert positive not in " ".join(anchor_tokens)
 
     @given(
         num_anchors=integers(min_value=1, max_value=4),
@@ -80,7 +83,7 @@ class TestContrastiveUtils:
     )
     def test_sample_spans_raises_value_error_invalid_min_span_length(
         self, num_anchors: int, num_positives: int
-    ):
+    ) -> None:
         text = "They may take our lives, but they'll never take our freedom!"
         num_tokens = len(self.tokenize(text))
 
@@ -102,7 +105,7 @@ class TestContrastiveUtils:
     )
     def test_sample_spans_raises_value_error_invalid_max_span_length(
         self, num_anchors: int, num_positives: int
-    ):
+    ) -> None:
         text = "They may take our lives, but they'll never take our freedom!"
         num_tokens = len(self.tokenize(text))
 

--- a/tests/common/test_data_utils.py
+++ b/tests/common/test_data_utils.py
@@ -8,7 +8,7 @@ from declutr.common.data_utils import sanitize
 
 class TestDataUtils:
     @given(text=text(), lowercase=booleans())
-    def test_sanitize(self, text: str, lowercase: bool):
+    def test_sanitize(self, text: str, lowercase: bool) -> None:
         sanitized_text = sanitize(text, lowercase=lowercase)
 
         # There should be no cases of multiple spaces or tabs

--- a/tests/common/test_model_utils.py
+++ b/tests/common/test_model_utils.py
@@ -15,7 +15,7 @@ class TestModelUtils:
         num_anchors=integers(min_value=1, max_value=4),
         max_length=integers(min_value=1, max_value=16),
     )
-    def test_unpack_batch(self, batch_size: int, num_anchors: int, max_length: int):
+    def test_unpack_batch(self, batch_size: int, num_anchors: int, max_length: int) -> None:
         # Create some dummy data.
         two_dim_tensor = torch.randn(batch_size, max_length)
         two_dim_input: TextFieldTensors = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,17 @@
+from typing import List
+
 import pytest
 from allennlp.common import util as common_util
 from allennlp.common.file_utils import cached_path
-from allennlp.models.archival import load_archive
+from allennlp.models.archival import Archive, load_archive
 from allennlp.predictors import Predictor
 
 from declutr.encoder import PRETRAINED_MODELS, Encoder
+from declutr.predictor import DeCLUTRPredictor
 
 
-@pytest.fixture(params=["declutr-small"])
-def encoder(request):
-    return Encoder(request.param)
-
-
-@pytest.fixture(params=["declutr-small"])
-def archive(request):
+@pytest.fixture(params=["declutr-small", "declutr-base"], scope="module")
+def archive(request) -> Archive:
     if request.param in PRETRAINED_MODELS:
         pretrained_model_name_or_path = PRETRAINED_MODELS[request.param]
     common_util.import_module_and_submodules("declutr")
@@ -21,6 +19,26 @@ def archive(request):
     return load_archive(pretrained_model_name_or_path)
 
 
-@pytest.fixture
-def predictor(archive):
+@pytest.fixture(scope="module")
+def predictor(archive) -> DeCLUTRPredictor:
     return Predictor.from_archive(archive, predictor_name="declutr")
+
+
+@pytest.fixture(params=["declutr-small", "declutr-base"], scope="module")
+def encoder(request) -> Encoder:
+    return Encoder(request.param)
+
+
+@pytest.fixture(scope="module")
+def inputs() -> List[str]:
+    # Some random examples taken from https://nlp.stanford.edu/projects/snli/
+    return [
+        "A man inspects the uniform of a figure in some East Asian country.",
+        "The man is sleeping",
+        "An older and younger man smiling.",
+        "Two men are smiling and laughing at the cats playing on the floor.",
+        "A black race car starts up in front of a crowd of people.",
+        "A man is driving down a lonely road.",
+        "A smiling costumed woman is holding an umbrella.",
+        "A happy woman in a fairy costume holds an umbrella.",
+    ]

--- a/tests/fixtures/experiment_scalar_mix.jsonnet
+++ b/tests/fixtures/experiment_scalar_mix.jsonnet
@@ -1,0 +1,29 @@
+local COMMON = import 'common.jsonnet';
+local transformer_model = "distilroberta-base";
+
+{
+    "dataset_reader": COMMON['dataset_reader'],
+    "datasets_for_vocab_creation": ["train"],
+    "train_data_path": COMMON['train_data_path'],
+    "validation_data_path": COMMON['validation_data_path'],
+    "model": {
+        "type": "declutr.DeCLUTR",
+        "text_field_embedder": {
+            "type": "declutr.modules.text_field_embedders.mlm_text_field_embedder.MLMTextFieldEmbedder",
+            "token_embedders": {
+                "tokens": {
+                    "type": "declutr.modules.token_embedders.pretrained_transformer_embedder_mlm.PretrainedTransformerEmbedderMLM",
+                    "model_name": transformer_model,
+                    "last_layer_only": false,
+                    "masked_language_modeling": true
+                },
+            },
+        },
+        "loss": {
+            "type": "declutr.losses.pytorch_metric_learning.NTXentLoss",
+            "temperature": 0.05,
+        },
+    },
+    "data_loader": COMMON['data_loader'],
+    "trainer": COMMON['trainer']
+}

--- a/tests/test_dataset_reader.py
+++ b/tests/test_dataset_reader.py
@@ -16,7 +16,7 @@ class TestDeCLUTRDatasetReader:
     )
     def test_no_sample_context_manager(
         self, num_anchors: int, num_positives: int, max_span_len: int, min_span_len: int
-    ):
+    ) -> None:
         dataset_reader = DeCLUTRDatasetReader(
             num_anchors=num_anchors,
             num_positives=num_positives,
@@ -40,7 +40,7 @@ class TestDeCLUTRDatasetReader:
     )
     def test_init_raises_value_error_sampling_missing_arguments(
         self, num_anchors: int, num_positives: int, max_span_len: int, min_span_len: int
-    ):
+    ) -> None:
         if num_anchors:  # should only raise the error when num_anchors is truthy
             with pytest.raises(ValueError):
                 _ = DeCLUTRDatasetReader(
@@ -85,7 +85,7 @@ class TestDeCLUTRDatasetReader:
         max_span_len: int,
         min_span_len: int,
         sampling_strategy: str,
-    ):
+    ) -> None:
         if num_anchors:  # should only raise the error when num_spans is truthy
             with pytest.raises(ValueError):
                 _ = DeCLUTRDatasetReader(

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,12 +1,38 @@
+from typing import List
+
+import pytest
+from hypothesis import given, settings
+from hypothesis.strategies import booleans
 from scipy.spatial.distance import cosine
+
+from declutr import Encoder
 
 
 class TestEncoder:
-    def test_encoder(self, encoder):
-        inputs = [
-            "A smiling costumed woman is holding an umbrella.",
-            "A happy woman in a fairy costume holds an umbrella.",
-            "Two men are smiling and laughing at the cats playing on the floor.",
-        ]
-        embeddings = encoder(inputs, batch_size=3)
-        assert cosine(embeddings[0], embeddings[1]) < cosine(embeddings[0], embeddings[2])
+    # The base model will take longer than the small model, which triggers a test timing error.
+    # Turn off deadlines to avoid this.
+    @settings(deadline=None)
+    @given(sphereize=booleans())
+    def test_encoder(self, inputs: List[str], encoder: Encoder, sphereize: bool) -> None:
+        # The last two of these three sentences are most similar.
+        inputs = inputs[-3:]
+
+        # The relative ranking should not change if sphereize is True/False, so run tests with both.
+        encoder._sphereize = sphereize
+
+        # Run two distinct tests, which should cover all use cases of Encoder:
+        #  1. A List[str] input where batch_size is not None.
+        embeddings = encoder(inputs, batch_size=len(inputs))
+        assert cosine(embeddings[0], embeddings[1]) > cosine(embeddings[1], embeddings[2])
+        assert cosine(embeddings[0], embeddings[2]) > cosine(embeddings[1], embeddings[2])
+
+        #  2. A str input where batch_size is None. Check that the expected UserWarning is raised.
+        embeddings = []
+        for text in inputs:
+            if sphereize:
+                with pytest.warns(UserWarning):
+                    embeddings.append(encoder(text, batch_size=None))
+            else:
+                embeddings.append(encoder(text, batch_size=None))
+        assert cosine(embeddings[0], embeddings[1]) > cosine(embeddings[1], embeddings[2])
+        assert cosine(embeddings[0], embeddings[2]) > cosine(embeddings[1], embeddings[2])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -61,6 +61,18 @@ class TestDeCLUTR(ModelTestCase):
         # Embeddings are not added to the output dict when training
         assert "embeddings" not in output_dict.keys()
 
+    def test_forward_pass_scalar_mix_runs_correctly(self):
+        self.set_up_model(
+            self.FIXTURES_ROOT / "experiment_scalar_mix.jsonnet",
+            self.FIXTURES_ROOT / "data" / "openwebtext" / "train.txt",
+        )
+        training_tensors = self.dataset.as_tensor_dict()
+        output_dict = self.model(**training_tensors)
+        output_dict = self.model.make_output_human_readable(output_dict)
+        assert "loss" in output_dict.keys()
+        # Embeddings are not added to the output dict when training
+        assert "embeddings" not in output_dict.keys()
+
     def test_no_loss_throws_configuration_error(self):
         params = Params.from_file(self.param_file)
         params["model"]["loss"] = None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -8,7 +8,7 @@ from allennlp.models import Model
 
 
 class TestDeCLUTR(ModelTestCase):
-    def setup_method(self):
+    def setup_method(self) -> None:
         super().setup_method()
         # We need to override the path set by AllenNLP
         self.FIXTURES_ROOT = Path("tests/fixtures")
@@ -17,7 +17,7 @@ class TestDeCLUTR(ModelTestCase):
             self.FIXTURES_ROOT / "data" / "openwebtext" / "train.txt",
         )
 
-    def test_forward_pass_runs_correctly(self):
+    def test_forward_pass_runs_correctly(self) -> None:
         training_tensors = self.dataset.as_tensor_dict()
         output_dict = self.model(**training_tensors)
         output_dict = self.model.make_output_human_readable(output_dict)
@@ -25,7 +25,7 @@ class TestDeCLUTR(ModelTestCase):
         # Embeddings are not added to the output dict when training
         assert "embeddings" not in output_dict.keys()
 
-    def test_forward_pass_with_feedforward_runs_correctly(self):
+    def test_forward_pass_with_feedforward_runs_correctly(self) -> None:
         self.set_up_model(
             self.FIXTURES_ROOT / "experiment_feedforward.jsonnet",
             self.FIXTURES_ROOT / "data" / "openwebtext" / "train.txt",
@@ -37,7 +37,7 @@ class TestDeCLUTR(ModelTestCase):
         # Embeddings are not added to the output dict when training
         assert "embeddings" not in output_dict.keys()
 
-    def test_forward_pass_contrastive_only_runs_correctly(self):
+    def test_forward_pass_contrastive_only_runs_correctly(self) -> None:
         self.set_up_model(
             self.FIXTURES_ROOT / "experiment_contrastive_only.jsonnet",
             self.FIXTURES_ROOT / "data" / "openwebtext" / "train.txt",
@@ -49,7 +49,7 @@ class TestDeCLUTR(ModelTestCase):
         # Embeddings are not added to the output dict when training
         assert "embeddings" not in output_dict.keys()
 
-    def test_forward_pass_mlm_only_runs_correctly(self):
+    def test_forward_pass_mlm_only_runs_correctly(self) -> None:
         self.set_up_model(
             self.FIXTURES_ROOT / "experiment_mlm_only.jsonnet",
             self.FIXTURES_ROOT / "data" / "openwebtext" / "train.txt",
@@ -61,7 +61,7 @@ class TestDeCLUTR(ModelTestCase):
         # Embeddings are not added to the output dict when training
         assert "embeddings" not in output_dict.keys()
 
-    def test_forward_pass_scalar_mix_runs_correctly(self):
+    def test_forward_pass_scalar_mix_runs_correctly(self) -> None:
         self.set_up_model(
             self.FIXTURES_ROOT / "experiment_scalar_mix.jsonnet",
             self.FIXTURES_ROOT / "data" / "openwebtext" / "train.txt",
@@ -73,7 +73,7 @@ class TestDeCLUTR(ModelTestCase):
         # Embeddings are not added to the output dict when training
         assert "embeddings" not in output_dict.keys()
 
-    def test_no_loss_throws_configuration_error(self):
+    def test_no_loss_throws_configuration_error(self) -> None:
         params = Params.from_file(self.param_file)
         params["model"]["loss"] = None
         params["model"]["text_field_embedder"]["token_embedders"]["tokens"][
@@ -83,5 +83,5 @@ class TestDeCLUTR(ModelTestCase):
             Model.from_params(vocab=self.vocab, params=params.get("model"))
 
     @pytest.mark.skip(reason="failing for upstream reasons")
-    def test_can_train_save_and_load(self):
+    def test_can_train_save_and_load(self) -> None:
         self.ensure_model_can_train_save_and_load(self.param_file)

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -1,5 +1,5 @@
 class TestDeCLUTRPredictor:
-    def test_json_to_instance(self, predictor):
+    def test_json_to_instance(self, predictor) -> None:
         json_dict = {"text": "They may take our lives, but they'll never take our freedom!"}
         output = predictor._json_to_instance(json_dict)
         assert "anchors" in output


### PR DESCRIPTION
# Overview

This PR updates `PretrainedTransformerEmbedderMLM` to support the new `ScalarMix` option in AllenNLP>=1.0.0. I am currently running some tests to see if this improves performance. If it does, I will make it the default.

