### PR TITLE
Use empty vocab

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,21 +97,6 @@ allennlp train "training_config/declutr.jsonnet" \
 
 The `--overrides` flag allows you to override any field in the config with a JSON-formatted string, but you can equivalently update the config itself if you prefer. During training, models, vocabulary, configuration, and log files will be saved to the directory provided by `--serialization-dir`. This can be changed to any directory you like. 
 
-#### Gotchas
-
-By default, `allennlp train` will create a vocabulary from our dataset (which can be slow depending on dataset size). Because our model comes with a pretrained vocabulary, we can skip this step by creating a new `"vocabulary"` directory which contains a single file `"non_padded_namespaces.txt"`
-
-```bash
-mkdir -p "path/to/your/dataset/vocabulary"
-echo "*tags\n*labels" > "path/to/your/dataset/vocabulary/non_padded_namespaces.txt"
-```
-
-and then specify this vocabulary in the call to `allennlp train`
-
-```bash
---overrides "{'vocabulary': {'type': 'from_files', 'directory': 'path/to/your/dataset/vocabulary'}}"
-```
-
 #### Multi-GPU training
 
 To train on more than one GPU, provide a list of CUDA devices in your call to `allennlp train`. For example, to train with four CUDA devices with IDs `0, 1, 2, 3`

--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -126,31 +126,6 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
-        "id": "jH3JAOBy_5dl"
-      },
-      "source": [
-        "By default, [`allennlp train`](https://docs.allennlp.org/master/api/commands/train/) will create a vocabulary for our dataset. Because our model comes with a pretrained vocabulary, we can skip this step by creating the following file under our dataset folder:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "Gh46STde_OTz",
-        "colab": {}
-      },
-      "source": [
-        "vocabulary_directory = \"wikitext_103/vocabulary\"\n",
-        "!mkdir -p $vocabulary_directory\n",
-        "!echo \"*tags\\n*labels\" > \"$vocabulary_directory/non_padded_namespaces.txt\""
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
         "id": "yUEFeupP6qy-"
       },
       "source": [
@@ -218,9 +193,7 @@
       },
       "source": [
         "\n",
-        "The only thing to configure is the path to the training set (`train_data_path`), and optionally, the `vocabulary`. Because our vocabulary is pretrained, specifying it here will prevent AllenNLP from trying to construct it again.\n",
-        "\n",
-        "Both arguments (`train_data_path` and `vocabulary`) can be passed to `allennlp train` via the `--overrides` argument (but you can also provide it in your config file directly, if you prefer):"
+        "The only thing to configure is the path to the training set (`train_data_path`), which can be passed to `allennlp train` via the `--overrides` argument (but you can also provide it in your config file directly, if you prefer):"
       ]
     },
     {
@@ -233,27 +206,11 @@
       "source": [
         "overrides = (\n",
         "    f\"{{'train_data_path': '{train_data_path}', \"\n",
-        "    f\"'vocabulary': {{'type': 'from_files', 'directory': '{vocabulary_directory}'}}, \"\n",
         "    # lower the batch size to be able to train on Colab GPUs\n",
         "    f\"'data_loader.batch_size': 2, \"\n",
         "    # training examples / batch size. Not required, but gives us a more informative progress bar during training\n",
         "    f\"'data_loader.batches_per_epoch': 8912}}\"\n",
         ")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "b7aKutgLZDxo",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "import logging\n",
-        "\n",
-        "logging.basicConfig(level=logging.ERROR)"
       ],
       "execution_count": null,
       "outputs": []

--- a/tests/fixtures/common.jsonnet
+++ b/tests/fixtures/common.jsonnet
@@ -6,6 +6,9 @@ local max_length = 16;
 local min_length = 8;
 
 {
+    "vocabulary": {
+        "type": "empty"
+    },
     "dataset_reader": {
         "type": "declutr.dataset_reader.DeCLUTRDatasetReader",
         "lazy": true,

--- a/tests/fixtures/experiment.jsonnet
+++ b/tests/fixtures/experiment.jsonnet
@@ -2,6 +2,7 @@ local COMMON = import 'common.jsonnet';
 local transformer_model = "distilroberta-base";
 
 {
+    "vocabulary": COMMON['vocabulary'],
     "dataset_reader": COMMON['dataset_reader'],
     "datasets_for_vocab_creation": ["train"],
     "train_data_path": COMMON['train_data_path'],

--- a/tests/fixtures/experiment_contrastive_only.jsonnet
+++ b/tests/fixtures/experiment_contrastive_only.jsonnet
@@ -2,6 +2,7 @@ local COMMON = import 'common.jsonnet';
 local transformer_model = "distilroberta-base";
 
 {
+    "vocabulary": COMMON['vocabulary'],
     "dataset_reader": COMMON['dataset_reader'],
     "datasets_for_vocab_creation": ["train"],
     "train_data_path": COMMON['train_data_path'],

--- a/tests/fixtures/experiment_feedforward.jsonnet
+++ b/tests/fixtures/experiment_feedforward.jsonnet
@@ -2,6 +2,7 @@ local COMMON = import 'common.jsonnet';
 local transformer_model = "distilroberta-base";
 
 {
+    "vocabulary": COMMON['vocabulary'],
     "dataset_reader": COMMON['dataset_reader'],
     "datasets_for_vocab_creation": ["train"],
     "train_data_path": COMMON['train_data_path'],

--- a/tests/fixtures/experiment_mlm_only.jsonnet
+++ b/tests/fixtures/experiment_mlm_only.jsonnet
@@ -2,6 +2,7 @@ local COMMON = import 'common.jsonnet';
 local transformer_model = "distilroberta-base";
 
 {
+    "vocabulary": COMMON['vocabulary'],
     "dataset_reader": COMMON['dataset_reader'],
     "datasets_for_vocab_creation": ["train"],
     "train_data_path": COMMON['train_data_path'],

--- a/tests/fixtures/experiment_scalar_mix.jsonnet
+++ b/tests/fixtures/experiment_scalar_mix.jsonnet
@@ -2,6 +2,7 @@ local COMMON = import 'common.jsonnet';
 local transformer_model = "distilroberta-base";
 
 {
+    "vocabulary": COMMON['vocabulary'],
     "dataset_reader": COMMON['dataset_reader'],
     "datasets_for_vocab_creation": ["train"],
     "train_data_path": COMMON['train_data_path'],

--- a/training_config/contrastive_only.jsonnet
+++ b/training_config/contrastive_only.jsonnet
@@ -7,6 +7,9 @@ local max_length = 512;
 local min_length = 32;
 
 {
+    "vocabulary": {
+        "type": "empty"
+    },
     "dataset_reader": {
         "type": "declutr",
         "lazy": true,

--- a/training_config/declutr.jsonnet
+++ b/training_config/declutr.jsonnet
@@ -7,6 +7,9 @@ local max_length = 512;
 local min_length = 32;
 
 {
+    "vocabulary": {
+        "type": "empty"
+    },
     "dataset_reader": {
         "type": "declutr",
         "lazy": true,

--- a/training_config/declutr_base.jsonnet
+++ b/training_config/declutr_base.jsonnet
@@ -7,6 +7,9 @@ local max_length = 512;
 local min_length = 32;
 
 {
+    "vocabulary": {
+        "type": "empty"
+    },
     "dataset_reader": {
         "type": "declutr",
         "lazy": true,

--- a/training_config/declutr_small.jsonnet
+++ b/training_config/declutr_small.jsonnet
@@ -7,6 +7,9 @@ local max_length = 512;
 local min_length = 32;
 
 {
+    "vocabulary": {
+        "type": "empty"
+    },
     "dataset_reader": {
         "type": "declutr",
         "lazy": true,

--- a/training_config/mlm_only.jsonnet
+++ b/training_config/mlm_only.jsonnet
@@ -7,6 +7,9 @@ local max_length = 512;
 local min_length = 32;
 
 {
+    "vocabulary": {
+        "type": "empty"
+    },
     "dataset_reader": {
         "type": "declutr",
         "lazy": true,

--- a/training_config/transformer_cls.jsonnet
+++ b/training_config/transformer_cls.jsonnet
@@ -11,6 +11,9 @@ local max_length = 512;
 local cls_is_last_token = false;
 
 {
+    "vocabulary": {
+        "type": "empty"
+    },
     "dataset_reader": {
         "type": "declutr",
         "lazy": true,

--- a/training_config/transformer_mean.jsonnet
+++ b/training_config/transformer_mean.jsonnet
@@ -6,6 +6,9 @@ local transformer_model = std.extVar("TRANSFORMER_MODEL");
 local max_length = 512;
 
 {
+    "vocabulary": {
+        "type": "empty"
+    },
     "dataset_reader": {
         "type": "declutr",
         "lazy": true,


### PR DESCRIPTION
# Overview

This PR uses an ["empty" Vocabulary](https://docs.allennlp.org/master/api/data/vocabulary/#empty) object by default, which should alleviate the need to specify a dummy vocab. This is one less step the user has to do.

## TODO

- [x] Test that the new code runs without error.
- [x] Update existing models with the new vocabulary.