### PR TITLE
Update build config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,26 +27,29 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        git clone https://github.com/allenai/allennlp.git
-        cd allennlp
-        pip install --editable .
-        cd ../
+        pip install git+https://github.com/allenai/allennlp.git
         pip install --editable ".[dev]"
     - name: Format code with black
       run: |
-        black -l 100 declutr
+        black .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 declutr --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings.
-        flake8 declutr --count --exit-zero --max-complexity=10 --max-line-length=115 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Test with pytest
       run: |
-        pytest tests -rf --cov ./declutr --cov-report=xml --cov-config=./.coveragerc 
+        pytest -q tests -n 2 --cov-report=xml --cov-config=./.coveragerc 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.7' && matrix.os == 'ubuntu-latest' && github.event_name == 'push'
+      # We don't want to push coverge for every job in the matrix.
+      # Rather arbitrarily, choose to push on Ubuntu with Python 3.8.
+      if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest' && github.event_name == 'push'
       uses: codecov/codecov-action@v1.0.12
       with:
         file: ./coverage.xml
+        # Ignore codecov failures as the codecov server is not
+        # very reliable but we don't want to report a failure
+        # in the github UI just because the coverage report failed to
+        # be published.
         fail_ci_if_error: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Test with pytest
       run: |
-        pytest -q tests -n 2 --cov-report=xml --cov-config=./.coveragerc 
+        pytest -q tests --cov-report=xml --cov-config=./.coveragerc 
     - name: Upload coverage to Codecov
       # We don't want to push coverge for every job in the matrix.
       # Rather arbitrarily, choose to push on Ubuntu with Python 3.8.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ The corresponding code for our paper: [DeCLUTR: Deep Contrastive Learning for Un
 
 | Model                                                                                                      | Requires labelled data? | Parameters | Embed. dim. | Downstream |  Probing  |    Avg.   |   Δ   |
 |------------------------------------------------------------------------------------------------------------|:-----------------------:|:----------:|:-----------:|:----------:|:---------:|:---------:|:-----:|
-| [InferSent V2](https://github.com/facebookresearch/InferSent)                                              |           Yes           |     38M    |     4096    |    76.46   |   72.58   |   75.07   | -1.55 |
-| [Universal Sentence Encoder](https://tfhub.dev/google/universal-sentence-encoder-large/5)                  |           Yes           |    147M    |     512     |  79.13 |   66.70   |   74.69   | -1.94 |
-| [Sentence Transformers](https://github.com/UKPLab/sentence-transformers)  ("roberta-base-nli-mean-tokens") |           Yes           |    125M    |     768     |    77.59   |   63.22   |   72.46   | -4.17 |
-| Transformer-small ([DistilRoBERTa-base](https://huggingface.co/distilroberta-base))                        |            No           |     82M    |     768     |    72.69   | 74.27 |   73.25   | -3.38 |
-| Transformer-base ([RoBERTa-base](https://huggingface.co/roberta-base))                                     |            No           |    125M    |     768     |    72.22   |   73.38   |   72.63   | -4.00 |
-| DeCLUTR-small ([DistilRoBERTa-base](https://huggingface.co/distilroberta-base))                            |            No           |     82M    |     768     |    77.52   |   73.90   |   76.23   | -0.40 |
-| DeCLUTR-base ([RoBERTa-base](https://huggingface.co/roberta-base))                                         |            No           |    125M    |     768     |    78.15   |   73.89   | __76.63__ |   --  |
+| [InferSent V2](https://github.com/facebookresearch/InferSent)                                              |           Yes           |     38M    |     4096    |    76.46   |   72.58   |   75.07   | -1.88 |
+| [Universal Sentence Encoder](https://tfhub.dev/google/universal-sentence-encoder-large/5)                  |           Yes           |    147M    |     512     |  __79.13__ |   66.70   |   74.69   | -2.26 |
+| [Sentence Transformers](https://github.com/UKPLab/sentence-transformers)  ("roberta-base-nli-mean-tokens") |           Yes           |    125M    |     768     |    77.59   |   63.22   |   72.46   | -4.49 |
+| Transformer-small ([DistilRoBERTa-base](https://huggingface.co/distilroberta-base))                        |            No           |     82M    |     768     |    72.69   |   74.27   |   73.25   | -3.70 |
+| Transformer-base ([RoBERTa-base](https://huggingface.co/roberta-base))                                     |            No           |    125M    |     768     |    72.22   |   73.38   |   72.63   | -4.32 |
+| DeCLUTR-small ([DistilRoBERTa-base](https://huggingface.co/distilroberta-base))                            |            No           |     82M    |     768     |    77.52   |   74.15   |   76.32   | -0.64 |
+| DeCLUTR-base ([RoBERTa-base](https://huggingface.co/roberta-base))                                         |            No           |    125M    |     768     |    78.34   | __74.45__ | __76.95__ |   --  |
 
-> Transformer-* is the same underlying architecture and pretrained weights as DeCLUTR-* _before_ continued training with our contrastive objective. Transformer-* and DeCLUTR-* use mean pooling on their token-level embeddings to produce a fixed-length sentence representation.
+> Transformer-* is the same underlying architecture and pretrained weights as DeCLUTR-* _before_ continued training with our contrastive objective. Transformer-* and DeCLUTR-* use mean pooling on their token-level embeddings to produce a fixed-length sentence representation. Δ is difference to DeCLUTR-base.
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ Before installing, you should create and activate a Python virtual environment. 
 
 ### Installing the library and dependencies
 
-First, clone the repository locally
+If you _don't_ plan on modifying the source code, install from `git` using `pip`
+
+```
+pip install git+https://github.com/JohnGiorgi/DeCLUTR.git
+```
+
+Otherwise, clone the repository locally and then install
 
 ```bash
 git clone https://github.com/JohnGiorgi/DeCLUTR.git
-```
-
-Then, install
-
-```bash
 cd DeCLUTR
 pip install --editable .
 ```

--- a/declutr/encoder.py
+++ b/declutr/encoder.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Union
 
 import torch
 from allennlp.common import util as common_util
-from allennlp.common.file_utils import cached_path
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
 
@@ -51,7 +50,6 @@ class Encoder:
     ) -> None:
         if pretrained_model_name_or_path in PRETRAINED_MODELS:
             pretrained_model_name_or_path = PRETRAINED_MODELS[pretrained_model_name_or_path]
-        pretrained_model_name_or_path = cached_path(pretrained_model_name_or_path)
         common_util.import_module_and_submodules("declutr")
         # Prevents a WARNING, which could confuse a user. Besides, performance is negatively
         # impacted when using mixed-precision during inference (in our case). Better to explicitly

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,15 @@ setuptools.setup(
     python_requires=">=3.6.1",
     install_requires=["allennlp>=1.0.0", "pytorch-metric-learning>=0.9.88", "typer>=0.3.0"],
     extras_require={
-        "dev": ["black", "flake8", "hypothesis", "pytest", "pytest-cov", "coverage", "codecov"]
+        "dev": [
+            "black",
+            "coverage",
+            "codecov",
+            "flake8",
+            "hypothesis",
+            "pytest",
+            "pytest-cov",
+            "pytest-xdist",
+        ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -42,15 +42,6 @@ setuptools.setup(
     python_requires=">=3.6.1",
     install_requires=["allennlp>=1.0.0", "pytorch-metric-learning>=0.9.88", "typer>=0.3.0"],
     extras_require={
-        "dev": [
-            "black",
-            "coverage",
-            "codecov",
-            "flake8",
-            "hypothesis",
-            "pytest",
-            "pytest-cov",
-            "pytest-xdist",
-        ]
+        "dev": ["black", "coverage", "codecov", "flake8", "hypothesis", "pytest", "pytest-cov"]
     },
 )


### PR DESCRIPTION
# Overview

Simplifies the build config by removing parameters that are already specified in config files and installing AllenNLP straight from `git`. Also, run the unit tests in parallel in 2 processes.

## Other changes

- :books: Simplify the install instructions.
- :recycle: Remove redundant `cache_path` code in `Encoder`.