### PR TITLE
Bump Pytorch Metric Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,6 @@ If you want to train with [mixed-precision](https://devblogs.nvidia.com/mixed-pr
 --overrides "{'trainer.opt_level': 'O1'}"
 ```
 
-#### Gotchas
-
-- Mixed-precision training will cause an error with the [PyTorch Metric Learning](https://github.com/KevinMusgrave/pytorch-metric-learning) library. See [here](https://github.com/JohnGiorgi/DeCLUTR/issues/60) for a discussion on the issue, along with the suggested fix.
-
 ### Embedding
 
 You can embed text with a trained model in one of three ways:

--- a/declutr/common/model_utils.py
+++ b/declutr/common/model_utils.py
@@ -56,8 +56,8 @@ def all_gather_anchor_positive_pairs(
     # Gather the encoded anchors and positives on all replicas
     anchors_list = [torch.ones_like(anchors) for _ in range(dist.get_world_size())]
     positives_list = [torch.ones_like(positives) for _ in range(dist.get_world_size())]
-    dist.all_gather(anchors_list, anchors.contigous())
-    dist.all_gather(positives_list, positives.contigous())
+    dist.all_gather(anchors_list, anchors.contiguous())
+    dist.all_gather(positives_list, positives.contiguous())
     # The gathered copy of the current replicas positive pairs have no gradients, so we overwrite
     # them with the positive pairs generated on this replica, which DO have gradients.
     anchors_list[dist.get_rank()] = anchors

--- a/declutr/common/model_utils.py
+++ b/declutr/common/model_utils.py
@@ -56,8 +56,8 @@ def all_gather_anchor_positive_pairs(
     # Gather the encoded anchors and positives on all replicas
     anchors_list = [torch.ones_like(anchors) for _ in range(dist.get_world_size())]
     positives_list = [torch.ones_like(positives) for _ in range(dist.get_world_size())]
-    dist.all_gather(anchors_list, anchors)
-    dist.all_gather(positives_list, positives)
+    dist.all_gather(anchors_list, anchors.contigous())
+    dist.all_gather(positives_list, positives.contigous())
     # The gathered copy of the current replicas positive pairs have no gradients, so we overwrite
     # them with the positive pairs generated on this replica, which DO have gradients.
     anchors_list[dist.get_rank()] = anchors

--- a/declutr/losses/pytorch_metric_learning.py
+++ b/declutr/losses/pytorch_metric_learning.py
@@ -83,6 +83,6 @@ class NTXentLoss(PyTorchMetricLearningLoss, losses.NTXentLoss):
     Registered as a `PyTorchMetricLearningLoss` with name "nt_xent".
     """
 
-    def __init__(self, temperature: float, normalize_embeddings: bool = True) -> None:
+    def __init__(self, temperature: float) -> None:
 
-        super().__init__(temperature=temperature, normalize_embeddings=normalize_embeddings)
+        super().__init__(temperature=temperature)

--- a/declutr/miners/pytorch_metric_learning.py
+++ b/declutr/miners/pytorch_metric_learning.py
@@ -28,7 +28,6 @@ class PairMarginMiner(PyTorchMetricLearningMiner, miners.PairMarginMiner):
         neg_margin: float,
         use_similarity: bool = True,
         squared_distances: bool = False,
-        normalize_embeddings: bool = True,
     ) -> None:
 
         super().__init__(
@@ -36,5 +35,4 @@ class PairMarginMiner(PyTorchMetricLearningMiner, miners.PairMarginMiner):
             neg_margin=neg_margin,
             use_similarity=use_similarity,
             squared_distances=squared_distances,
-            normalize_embeddings=normalize_embeddings,
         )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "Typing :: Typed",
     ],
     python_requires=">=3.6.1",
-    install_requires=["allennlp>=1.0.0", "pytorch-metric-learning>=0.9.88", "typer>=0.3.0"],
+    install_requires=["allennlp>=1.0.0", "pytorch-metric-learning>=0.9.90", "typer>=0.3.0"],
     extras_require={
         "dev": ["black", "coverage", "codecov", "flake8", "hypothesis", "pytest", "pytest-cov"]
     },


### PR DESCRIPTION
# Overview

This PR bumps the Pytorch Metric Learning dependency.

## Other changes

- :bug: Fixes a tricky bug that arises on multiple-GPUs when `anchors` or `positives` are not contiguous.

## Closes

Closes #60.