### PR TITLE
Use amp by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,7 @@ To train on more than one GPU, provide a list of CUDA devices in your call to `a
 
 #### Training with mixed-precision
 
-If you want to train with [mixed-precision](https://devblogs.nvidia.com/mixed-precision-training-deep-neural-networks/) (strongly recommended if your GPU supports it), you need only to set `"use_amp"` to `true` in your training [config](training_config), or, equivalently, pass the following flag to `allennlp train`
-
-```bash
---overrides "{'trainer.use_amp: true}"
-```
+If your GPU supports it, [mixed-precision](https://devblogs.nvidia.com/mixed-precision-training-deep-neural-networks/) will be used automatically during training and inference.
 
 ### Embedding
 

--- a/declutr/encoder.py
+++ b/declutr/encoder.py
@@ -51,11 +51,7 @@ class Encoder:
         if pretrained_model_name_or_path in PRETRAINED_MODELS:
             pretrained_model_name_or_path = PRETRAINED_MODELS[pretrained_model_name_or_path]
         common_util.import_module_and_submodules("declutr")
-        # Prevents a WARNING, which could confuse a user. Besides, performance is negatively
-        # impacted when using mixed-precision during inference (in our case). Better to explicitly
-        # prevent this scenario from happening.
-        overrides = "{'trainer.use_amp': false}"
-        archive = load_archive(pretrained_model_name_or_path, overrides=overrides, **kwargs)
+        archive = load_archive(pretrained_model_name_or_path, **kwargs)
         self._predictor = Predictor.from_archive(archive, predictor_name="declutr")
         self._output_dict_field = "embeddings"
         self._sphereize = sphereize
@@ -64,6 +60,15 @@ class Encoder:
     def __call__(
         self, inputs: Union[str, List[str]], batch_size: Optional[int] = None
     ) -> torch.Tensor:
+        """Returns a numpy array of embeddings, one for each item in `inputs`.
+
+        # Parameters
+
+        inputs : `Union[str, List[str]]`, required
+            The input text to embed. Can be a string or list of strings.
+        batch_size : `int`, optional
+            If given, the `inputs` will be batched before embedding.
+        """
         if isinstance(inputs, str):
             inputs = [inputs]
         if batch_size is None:

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -692,7 +692,7 @@ def allennlp(
 
     # Load the archived Model
     archive = load_archive(
-        path_to_allennlp_archive, cuda_device=cuda_device, use_amp=False, weights_file=weights_file,
+        path_to_allennlp_archive, cuda_device=cuda_device, weights_file=weights_file,
     )
     predictor = Predictor.from_archive(archive, predictor_name)
     typer.secho(

--- a/scripts/save_pretrained_hf.py
+++ b/scripts/save_pretrained_hf.py
@@ -18,10 +18,9 @@ def main(archive_file: str, save_directory: str) -> None:
     save_directory.parents[0].mkdir(parents=True, exist_ok=True)
 
     common_util.import_module_and_submodules("declutr")
-    # use_amp=false prevents a WARNING, which could confuse a user.
     # cuda_device -1 places the model onto the CPU before saving. This avoids issues with
     # distributed models.
-    overrides = "{'trainer.use_amp': false, 'trainer.cuda_device': -1}"
+    overrides = "{'trainer.cuda_device': -1}"
     archive = load_archive(archive_file, overrides=overrides)
     predictor = Predictor.from_archive(archive, predictor_name="declutr")
 

--- a/training_config/contrastive_only.jsonnet
+++ b/training_config/contrastive_only.jsonnet
@@ -55,7 +55,7 @@ local min_length = 32;
     },
     "trainer": {
         // Set use_amp to true to use automatic mixed-precision during training (if your GPU supports it)
-        "use_amp": false,
+        "use_amp": true,
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,

--- a/training_config/declutr.jsonnet
+++ b/training_config/declutr.jsonnet
@@ -55,7 +55,7 @@ local min_length = 32;
     },
     "trainer": {
         // Set use_amp to true to use automatic mixed-precision during training (if your GPU supports it)
-        "use_amp": false,
+        "use_amp": true,
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,

--- a/training_config/declutr_base.jsonnet
+++ b/training_config/declutr_base.jsonnet
@@ -55,7 +55,7 @@ local min_length = 32;
     },
     "trainer": {
         // Set use_amp to true to use automatic mixed-precision during training (if your GPU supports it)
-        "use_amp": false,
+        "use_amp": true,
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,

--- a/training_config/declutr_small.jsonnet
+++ b/training_config/declutr_small.jsonnet
@@ -55,7 +55,7 @@ local min_length = 32;
     },
     "trainer": {
         // Set use_amp to true to use automatic mixed-precision during training (if your GPU supports it)
-        "use_amp": false,
+        "use_amp": true,
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,

--- a/training_config/mlm_only.jsonnet
+++ b/training_config/mlm_only.jsonnet
@@ -54,7 +54,7 @@ local min_length = 32;
     },
     "trainer": {
         // Set use_amp to true to use automatic mixed-precision during training (if your GPU supports it)
-        "use_amp": false,
+        "use_amp": true,
         "optimizer": {
             "type": "huggingface_adamw",
             "lr": 5e-5,


### PR DESCRIPTION
# Overview

If the GPU supports it, default to using automatic mixed precision in training and inference. I can't think of a good reason for this not to be the default, as it speeds up training and lowers memory use without impacting model performance. It also simplifies things for the user, as they no longer need to specify `use_amp: true`.