### PR TITLE
Support encoding from file or URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,12 @@ setuptools.setup(
         "Typing :: Typed",
     ],
     python_requires=">=3.6.1",
-    install_requires=["allennlp>=1.0.0", "pytorch-metric-learning>=0.9.90", "typer>=0.3.0"],
+    install_requires=[
+        "allennlp>=1.0.0",
+        "pytorch-metric-learning>=0.9.90",
+        "typer>=0.3.0",
+        "validators>=0.18.0",
+    ],
     extras_require={
         "dev": ["black", "coverage", "codecov", "flake8", "hypothesis", "pytest", "pytest-cov"]
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ from allennlp.predictors import Predictor
 from declutr.encoder import PRETRAINED_MODELS, Encoder
 from declutr.predictor import DeCLUTRPredictor
 
+# Note: Most of these are scoped as "module" to prevent a warning from hypothesis
+# about fixtures being reset between function calls.
+
 
 @pytest.fixture(params=["declutr-small", "declutr-base"], scope="module")
 def archive(request) -> Archive:
@@ -30,13 +33,13 @@ def encoder(request) -> Encoder:
     return Encoder(request.param)
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def inputs_filepath() -> str:
     # Some random examples taken from https://nlp.stanford.edu/projects/snli/
     return "tests/fixtures/data/encoder_inputs.txt"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def inputs(inputs_filepath) -> List[str]:
     # Some random examples taken from https://nlp.stanford.edu/projects/snli/
     return Path(inputs_filepath).read_text().split("\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import List
 
 import pytest
@@ -29,16 +30,13 @@ def encoder(request) -> Encoder:
     return Encoder(request.param)
 
 
-@pytest.fixture(scope="module")
-def inputs() -> List[str]:
+@pytest.fixture()
+def inputs_filepath() -> str:
     # Some random examples taken from https://nlp.stanford.edu/projects/snli/
-    return [
-        "A man inspects the uniform of a figure in some East Asian country.",
-        "The man is sleeping",
-        "An older and younger man smiling.",
-        "Two men are smiling and laughing at the cats playing on the floor.",
-        "A black race car starts up in front of a crowd of people.",
-        "A man is driving down a lonely road.",
-        "A smiling costumed woman is holding an umbrella.",
-        "A happy woman in a fairy costume holds an umbrella.",
-    ]
+    return "tests/fixtures/data/encoder_inputs.txt"
+
+
+@pytest.fixture()
+def inputs(inputs_filepath) -> List[str]:
+    # Some random examples taken from https://nlp.stanford.edu/projects/snli/
+    return Path(inputs_filepath).read_text().split("\n")

--- a/tests/fixtures/data/encoder_inputs.txt
+++ b/tests/fixtures/data/encoder_inputs.txt
@@ -1,0 +1,8 @@
+"A man inspects the uniform of a figure in some East Asian country."
+"The man is sleeping"
+"An older and younger man smiling."
+"Two men are smiling and laughing at the cats playing on the floor."
+"A black race car starts up in front of a crowd of people."
+"A man is driving down a lonely road."
+"A smiling costumed woman is holding an umbrella."
+"A happy woman in a fairy costume holds an umbrella."

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import List
 
 import pytest
@@ -13,14 +14,13 @@ class TestEncoder:
     # Turn off deadlines to avoid this.
     @settings(deadline=None)
     @given(sphereize=booleans())
-    def test_encoder(self, inputs: List[str], encoder: Encoder, sphereize: bool) -> None:
-        # The last two of these three sentences are most similar.
-        inputs = inputs[-3:]
-
+    def test_encoder(
+        self, inputs: List[str], inputs_filepath: Path, encoder: Encoder, sphereize: bool
+    ) -> None:
         # The relative ranking should not change if sphereize is True/False, so run tests with both.
         encoder._sphereize = sphereize
 
-        # Run two distinct tests, which should cover all use cases of Encoder:
+        # Run three distinct tests, which should cover all use cases of Encoder:
         #  1. A List[str] input where batch_size is not None.
         embeddings = encoder(inputs, batch_size=len(inputs))
         assert cosine(embeddings[0], embeddings[1]) > cosine(embeddings[1], embeddings[2])
@@ -34,5 +34,10 @@ class TestEncoder:
                     embeddings.append(encoder(text, batch_size=None))
             else:
                 embeddings.append(encoder(text, batch_size=None))
+        assert cosine(embeddings[0], embeddings[1]) > cosine(embeddings[1], embeddings[2])
+        assert cosine(embeddings[0], embeddings[2]) > cosine(embeddings[1], embeddings[2])
+
+        #  3. A filepath input that points to file with one example per line.
+        embeddings = encoder(inputs_filepath, batch_size=len(inputs))
         assert cosine(embeddings[0], embeddings[1]) > cosine(embeddings[1], embeddings[2])
         assert cosine(embeddings[0], embeddings[2]) > cosine(embeddings[1], embeddings[2])


### PR DESCRIPTION
# Overview

This PR enables `Encoder` to accept a filepath or URL pointing to a file, with one example per line. This is in addition to accepting a string or list of strings.

## Other changes

- Apply the same minimal text sanitation applied at train time.