### PR TITLE
Upgrade to allennlp 1.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/allenai/allennlp.git
         pip install --editable ".[dev]"
     - name: Format code with black
       run: |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ pip install --editable .
 
 #### Gotchas
 
-- For the time being, please install [AllenNLP](https://github.com/allenai/allennlp) [from source](https://github.com/allenai/allennlp#installing-from-source).
 - If you plan on training your own model, you should also install [PyTorch](https://pytorch.org/) with [CUDA](https://developer.nvidia.com/cuda-zone) support by following the instructions for your system [here](https://pytorch.org/get-started/locally/).
 
 ## Usage

--- a/declutr/modules/token_embedders/pretrained_transformer_embedder_mlm.py
+++ b/declutr/modules/token_embedders/pretrained_transformer_embedder_mlm.py
@@ -41,6 +41,8 @@ class PretrainedTransformerEmbedderMLM(PretrainedTransformerEmbedder):
         When `True` (the default), only the final layer of the pretrained transformer is taken
         for the embeddings. But if set to `False`, a scalar mix of all of the layers
         is used.
+    gradient_checkpointing: `bool`, optional (default = `None`)
+        Enable or disable gradient checkpointing.
     """
 
     def __init__(
@@ -53,6 +55,7 @@ class PretrainedTransformerEmbedderMLM(PretrainedTransformerEmbedder):
         last_layer_only: bool = True,
         override_weights_file: Optional[str] = None,
         override_weights_strip_prefix: Optional[str] = None,
+        gradient_checkpointing: Optional[bool] = None,
         masked_language_modeling: bool = True,
     ) -> None:
         TokenEmbedder.__init__(self)  # Call the base class constructor
@@ -78,6 +81,9 @@ class PretrainedTransformerEmbedderMLM(PretrainedTransformerEmbedder):
                 model_name, True, override_weights_file, override_weights_strip_prefix
             )
             self.config = self.transformer_model.config
+
+        if gradient_checkpointing is not None:
+            self.transformer_model.config.update({"gradient_checkpointing": gradient_checkpointing})
 
         if sub_module:
             assert hasattr(self.transformer_model, sub_module)

--- a/notebooks/embedding.ipynb
+++ b/notebooks/embedding.ipynb
@@ -64,29 +64,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "-mgoqjZNxC4G",
-        "colab_type": "text"
-      },
-      "source": [
-        "For the time being, please install AllenNLP from source"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "HiJxjPqHxC4K",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "!pip install git+https://github.com/allenai/allennlp.git"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "iV_jB7IZxC4d",
         "colab_type": "text"
       },

--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -55,29 +55,6 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
-        "id": "NLbVUQ01ObYd"
-      },
-      "source": [
-        "For the time being, please install AllenNLP from source"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "nUb2l5xsObYf",
-        "colab": {}
-      },
-      "source": [
-        "!pip install git+https://github.com/allenai/allennlp.git"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
         "id": "Zog7ApwuUD7_"
       },
       "source": [

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     ],
     python_requires=">=3.6.1",
     install_requires=[
-        "allennlp>=1.0.0",
+        "allennlp>=1.1.0",
         "pytorch-metric-learning>=0.9.90",
         "typer>=0.3.0",
         "validators>=0.18.0",


### PR DESCRIPTION
# Overview

Does everything necessary to bump AllenNLP requirement to 1.1.0. This removes the need to install AllenNLP from source.

## TODO

- [x] Make sure our subclasses are up-to-date.