### PR TITLE
Constrain allennlp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     ],
     python_requires=">=3.6.1",
     install_requires=[
-        "allennlp>=1.2.1",
+        "allennlp>=1.1.0, <1.2.0",
         "pytorch-metric-learning>=0.9.93",
         "typer>=0.3.2",
         "validators>=0.18.1",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     ],
     python_requires=">=3.6.1",
     install_requires=[
-        "allennlp>=1.1.0",
+        "allennlp>=1.2.1",
         "pytorch-metric-learning>=0.9.93",
         "typer>=0.3.2",
         "validators>=0.18.1",


### PR DESCRIPTION
# Overview

This PR constrains the allennlp dependency to versions `"allennlp>=1.1.0, <1.2.0"` to prevent the error mentioned in #164. This should get the CI/CD build passing again.