### PR TITLE
Add evaluation notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The text embeddings are stored in the field `"embeddings"` in `"output/embedding
 
 ### Evaluating with SentEval
 
-[SentEval](https://github.com/facebookresearch/SentEval) is a library for evaluating the quality of sentence embeddings. We provide a script to evaluate our model against SentEval. The easiest way to evaluate our models or the baselines we compare to is by using the [provided notebook](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/evaluating.ipynb). Broadly, the steps are the following:
+[SentEval](https://github.com/facebookresearch/SentEval) is a library for evaluating the quality of sentence embeddings. We provide a script to evaluate our model against SentEval. We have provided a [notebook](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/evaluating.ipynb) that documents the process of evaluating a trained model on SentEval. Broadly, the steps are the following:
 
 First, clone the SentEval repository and download the transfer task datasets (you only need to do this once)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The easiest way to get started is to follow along with one of our [notebooks](no
 
 - Training your own model [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/training.ipynb)
 - Embedding text with a pretrained model [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/embedding.ipynb)
+- Evaluating a model with [SentEval](https://github.com/facebookresearch/SentEval) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/evaluating.ipynb)
 
 ## Installation
 
@@ -171,15 +172,15 @@ tokenizer = AutoTokenizer.from_pretrained("johngiorgi/declutr-small")
 model = AutoModel.from_pretrained("johngiorgi/declutr-small")
 
 # Prepare some text to embed
-text = [
+texts = [
     "A smiling costumed woman is holding an umbrella.",
     "A happy woman in a fairy costume holds an umbrella.",
 ]
-inputs = tokenizer(text, padding=True, truncation=True, return_tensors="pt")
+inputs = tokenizer(texts, padding=True, truncation=True, return_tensors="pt")
 
 # Embed the text
 with torch.no_grad():
-    sequence_output, _ = model(**inputs, output_hidden_states=False)
+    sequence_output = model(**inputs)[0]
 
 # Mean pool the token-level embeddings to get sentence-level embeddings
 embeddings = torch.sum(
@@ -214,7 +215,7 @@ The text embeddings are stored in the field `"embeddings"` in `"output/embedding
 
 ### Evaluating with SentEval
 
-[SentEval](https://github.com/facebookresearch/SentEval) is a library for evaluating the quality of sentence embeddings. We provide a script to evaluate our model against SentEval.
+[SentEval](https://github.com/facebookresearch/SentEval) is a library for evaluating the quality of sentence embeddings. We provide a script to evaluate our model against SentEval. The easiest way to evaluate our models or the baselines we compare to is by using the [provided notebook](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/evaluating.ipynb). Broadly, the steps are the following:
 
 First, clone the SentEval repository and download the transfer task datasets (you only need to do this once)
 

--- a/notebooks/evaluating.ipynb
+++ b/notebooks/evaluating.ipynb
@@ -1,0 +1,208 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "evaluating.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "LY9LO9FnSPIa"
+      },
+      "source": [
+        "# Evaluating a model\n",
+        "\n",
+        "This notebook will walk you through evaluating a [DeCLUTR](https://github.com/JohnGiorgi/DeCLUTR) model with [SentEval](https://github.com/facebookresearch/SentEval)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZbZ4o1HHSM5t"
+      },
+      "source": [
+        "## 🔧 Install the prerequisites\n",
+        "\n",
+        "Clone to repository locally so we have access to the evaluation scripts. Then install DeCLUTR"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "fdyoe-EPSKLN"
+      },
+      "source": [
+        "%%bash\n",
+        "git clone https://github.com/JohnGiorgi/DeCLUTR.git\n",
+        "cd DeCLUTR\n",
+        "pip install -e .\n",
+        "cd ../"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "5o1owrdbWDl9"
+      },
+      "source": [
+        "Next, we have to clone the SentEval benchmark locally (this will take a few minutes)\n",
+        "\n",
+        "> Note that we will also have to pull two files from a contributor to fix a bug in the SNLI task evaluation. See [here](https://github.com/facebookresearch/SentEval/pull/52) for details."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "_9Mg77kOREs7"
+      },
+      "source": [
+        "%%bash\n",
+        "git clone https://github.com/facebookresearch/SentEval.git\n",
+        "# SNLI evaluation in SentEval is broken. Download two files from a contributor that fix the error\n",
+        "# See: https://github.com/facebookresearch/SentEval/pull/52\n",
+        "(cd SentEval/senteval; curl -O https://raw.githubusercontent.com/facebookresearch/SentEval/0291f274d7674fb6a1ea8fb7a58426ab28adeb0f/senteval/snli.py)\n",
+        "(cd SentEval/senteval/tools; curl -O https://raw.githubusercontent.com/facebookresearch/SentEval/0291f274d7674fb6a1ea8fb7a58426ab28adeb0f/senteval/tools/validation.py)\n",
+        "cd SentEval/data/downstream/\n",
+        "./get_transfer_data.bash\n",
+        "cd ../../../"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "m05mAP5wWU-f"
+      },
+      "source": [
+        "Lastly, we need a model to evaluate. We will download `DeCLUTR-small`:\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "0Nd8oYGpUn5k"
+      },
+      "source": [
+        "!wget https://github.com/JohnGiorgi/DeCLUTR/releases/download/v0.1.0rc1/declutr-small.tar.gz"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3ae7g5puWn8X"
+      },
+      "source": [
+        "## 📋 Evaluating the model\n",
+        "\n",
+        "Finally, use our provided script to evaluate the model on SentEval.\n",
+        "\n",
+        "> Note, the script will evaluate on all 28 SentEval tasks. This can take 7 hours or more on a GPU."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "zLWGGQSJUwW1"
+      },
+      "source": [
+        "!python DeCLUTR/scripts/run_senteval.py allennlp \"SentEval\" \"declutr-small.tar.gz\" \\\n",
+        " --output-filepath \"senteval_results.json\" \\\n",
+        " --cuda-device 0  \\\n",
+        " --include-package \"declutr\" \\\n",
+        " --verbose"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "MLRyWa1IXepJ"
+      },
+      "source": [
+        "We also provide commands for evaluating other popular sentence encoders. For a list of commands, run:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "GWdKsXc_W6TC"
+      },
+      "source": [
+        "!python DeCLUTR/scripts/run_senteval.py --help"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OCNuiVzLXozu"
+      },
+      "source": [
+        "For help with a specific command, e.g. `transformers`, run:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "XEbSmYIVWNoB"
+      },
+      "source": [
+        "!python DeCLUTR/scripts/run_senteval.py transformers --help"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AZyXiAmHX3RF"
+      },
+      "source": [
+        "Notice that evaluate other popular models, like [Sentence Transformers](https://www.sbert.net/)! Just make sure to install it first:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "samad0pSbg4N"
+      },
+      "source": [
+        "!pip install sentence-transformers"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "V1kN71RBXtwB"
+      },
+      "source": [
+        "!python DeCLUTR/scripts/run_senteval.py sentence-transformers \"SentEval\" \"roberta-base-nli-mean-tokens\" \\\n",
+        " --output-filepath \"senteval_results.json\" \\\n",
+        " --cuda-device 0  \\\n",
+        " --verbose"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/scripts/preprocess_openwebtext.py
+++ b/scripts/preprocess_openwebtext.py
@@ -2,10 +2,10 @@
 import shutil
 import tarfile
 from pathlib import Path
-from typing import List, Optional
-from declutr.common.data_utils import sanitize
+from typing import List, Optional, Union
 
 import typer
+from declutr.common.data_utils import sanitize
 
 # Emoji's used in typer.secho calls
 # See: https://github.com/carpedm20/emoji/blob/master/emoji/unicode_codes.py"
@@ -14,7 +14,7 @@ SAVING = "\U0001F4BE"
 MINING = "\U000026CF"
 
 
-def _write_output_to_disk(text: List[str], output_filepath: str) -> None:
+def _write_output_to_disk(text: List[str], output_filepath: Union[str, Path]) -> None:
     """Writes a list of documents, `text`, to the file `output_filepath`, one document per line."""
     # Create the directory path if it doesn't exist
     output_filepath = Path(output_filepath)
@@ -36,8 +36,8 @@ def _write_output_to_disk(text: List[str], output_filepath: str) -> None:
 
 
 def main(
-    openwebtext_path: str,
-    output_filepath: str,
+    openwebtext_path: Union[str, Path],
+    output_filepath: Union[str, Path],
     min_length: Optional[int] = None,
     lowercase: bool = True,
     max_documents: Optional[int] = None,
@@ -96,10 +96,11 @@ def main(
                 if not text:
                     continue
 
-                # Retain documents if # of tokens is greater than the minimum specified length
+                # Retain documents if the length of their shortest document is
+                # equal to or greater than the minimum specified length
                 if tokenizer is not None:
                     num_tokens = len(tokenizer(text))
-                    if num_tokens < min_length:
+                    if min_length and num_tokens < min_length:
                         continue
 
                 documents.append(text)

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -93,7 +93,7 @@ def _get_device(cuda_device: int) -> torch.device:
 def _print_aggregate_scores(aggregate_scores: Dict[str, Dict[str, float]]) -> None:
     """Prints out nicely formatted `aggregate_scores`."""
     for partition in ["dev", "test"]:
-        typer.secho(f"{SCORE} Aggregate {partition} scores", fg=typer.colors.WHITE, bold=True)
+        typer.secho(f"{SCORE} Aggregate {partition} scores", bold=True)
         for task_set in ["downstream", "probing", "all"]:
             typer.secho(f"* {task_set.title()}: {aggregate_scores[task_set][partition]:.2f}%")
 
@@ -229,7 +229,7 @@ def _run_senteval(
         bold=True,
     )
     typer.secho(
-        f"{RUNNING} Running evaluation. This may take a while!", fg=typer.colors.WHITE, bold=True
+        f"{RUNNING} Running evaluation. This may take a while!", bold=True
     )
 
     se = senteval.engine.SE(params, batcher, prepare)
@@ -250,7 +250,7 @@ def _run_senteval(
             json_safe_results[AGGREGATE_SCORES_KEY] = aggregate_scores
             json.dump(json_safe_results, fp, indent=2)
         typer.secho(
-            f"{SAVING} Results saved to: {output_filepath}", fg=typer.colors.WHITE, bold=True
+            f"{SAVING} Results saved to: {output_filepath}", bold=True
         )
     else:
         typer.secho(
@@ -283,7 +283,8 @@ def random(
     prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
-    """Sanity check that evaluates randomly initialized vectors against the SentEval benchmark."""
+    """Sanity check that evaluates randomly initialized vectors against the SentEval benchmark.
+    """
 
     # SentEval prepare and batcher
     def prepare(params, samples):
@@ -524,7 +525,8 @@ def transformers(
     prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
-    """Evaluates a pre-trained model from the Transformers library against the SentEval benchmark."""
+    """Evaluates a pre-trained model from the Transformers library against the SentEval benchmark.
+    """
 
     from transformers import AutoModel, AutoTokenizer
 
@@ -660,7 +662,8 @@ def allennlp(
     prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
-    """Evaluates a trained AllenNLP model against the SentEval benchmark."""
+    """Evaluates a trained AllenNLP model against the SentEval benchmark.
+    """
 
     from allennlp.models.archival import load_archive
     from allennlp.predictors import Predictor

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -6,7 +6,7 @@ import os
 import sys
 from pathlib import Path
 from statistics import mean
-from typing import Callable, Iterable, List, Union, Dict
+from typing import Any, Callable, Dict, Iterable, List, Union
 
 import numpy as np
 import torch
@@ -66,7 +66,7 @@ FAST = "\U0001F3C3"
 SCORE = "\U0001F4CB"
 
 
-def _cleanup_batch(batch: List[Iterable[Union[str, bytes]]]) -> List[Iterable[str]]:
+def _cleanup_batch(batch: List[Iterable[Union[str, bytes]]]) -> List[Iterable[Union[str, bytes]]]:
     batch = [
         [
             token.decode("utf-8", errors="ignore") if isinstance(token, bytes) else token
@@ -98,9 +98,7 @@ def _print_aggregate_scores(aggregate_scores: Dict[str, Dict[str, float]]) -> No
             typer.secho(f"* {task_set.title()}: {aggregate_scores[task_set][partition]:.2f}%")
 
 
-def _compute_aggregate_scores(
-    results: Dict, ignore_tasks: List[str] = None
-) -> Dict[str, Dict[str, float]]:
+def _compute_aggregate_scores(results: Dict, ignore_tasks: List[str] = None) -> Dict[str, Any]:
     """Computes aggregate scores for the dev and test sets for the given SentEval `results`. Tasks
     can be ignored (e.g. their score will not be computed and therefore not contribute to the
     aggregate score) by passing the task name in the list `ignore_tasks`.
@@ -113,7 +111,7 @@ def _compute_aggregate_scores(
         # Unclear why this is cast as tuple, the type hint is List[str]?
         else list(ignore_tasks) + [AGGREGATE_SCORES_KEY]
     )
-    aggregate_scores = {
+    aggregate_scores: Dict[str, Any] = {
         "downstream": {"dev": 0, "test": 0},
         "probing": {"dev": 0, "test": 0},
         "all": {},
@@ -179,7 +177,7 @@ def _compute_aggregate_scores(
 
 def _setup_senteval(
     path_to_senteval: str, prototyping_config: bool = False, verbose: bool = False
-) -> None:
+) -> Dict[str, Any]:
     if verbose:
         logging.basicConfig(format="%(asctime)s : %(message)s", level=logging.DEBUG)
 
@@ -218,7 +216,11 @@ def _setup_senteval(
 
 
 def _run_senteval(
-    params, path_to_senteval: str, batcher: Callable, prepare: Callable, output_filepath: str = None
+    params,
+    path_to_senteval: str,
+    batcher: Callable,
+    prepare: Callable,
+    output_filepath: Union[str, Path] = None,
 ) -> None:
     sys.path.insert(0, path_to_senteval)
     import senteval

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -228,9 +228,7 @@ def _run_senteval(
         fg=typer.colors.GREEN,
         bold=True,
     )
-    typer.secho(
-        f"{RUNNING} Running evaluation. This may take a while!", bold=True
-    )
+    typer.secho(f"{RUNNING} Running evaluation. This may take a while!", bold=True)
 
     se = senteval.engine.SE(params, batcher, prepare)
     results = se.eval(TRANSFER_TASKS)
@@ -249,9 +247,7 @@ def _run_senteval(
             # Add aggregate scores to results dict
             json_safe_results[AGGREGATE_SCORES_KEY] = aggregate_scores
             json.dump(json_safe_results, fp, indent=2)
-        typer.secho(
-            f"{SAVING} Results saved to: {output_filepath}", bold=True
-        )
+        typer.secho(f"{SAVING} Results saved to: {output_filepath}", bold=True)
     else:
         typer.secho(
             f"{WARNING} --output-filepath was not provided, printing results to console instead.",
@@ -283,8 +279,7 @@ def random(
     prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
-    """Sanity check that evaluates randomly initialized vectors against the SentEval benchmark.
-    """
+    """Sanity check that evaluates randomly initialized vectors against the SentEval benchmark."""
 
     # SentEval prepare and batcher
     def prepare(params, samples):
@@ -525,8 +520,7 @@ def transformers(
     prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
-    """Evaluates a pre-trained model from the Transformers library against the SentEval benchmark.
-    """
+    """Evaluates a pre-trained model from the Transformers library against the SentEval benchmark."""
 
     from transformers import AutoModel, AutoTokenizer
 
@@ -662,8 +656,7 @@ def allennlp(
     prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
-    """Evaluates a trained AllenNLP model against the SentEval benchmark.
-    """
+    """Evaluates a trained AllenNLP model against the SentEval benchmark."""
 
     from allennlp.models.archival import load_archive
     from allennlp.predictors import Predictor

--- a/scripts/save_pretrained_hf.py
+++ b/scripts/save_pretrained_hf.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import typer
+import Union
 from allennlp.common import util as common_util
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
@@ -11,7 +12,7 @@ SAVING = "\U0001F4BE"
 HUGGING_FACE = "\U0001F917"
 
 
-def main(archive_file: str, save_directory: str) -> None:
+def main(archive_file: str, save_directory: Union[str, Path]) -> None:
     """Saves the model and tokenizer from an AllenNLP `archive_file` path pointing to a trained
     DeCLUTR model to a format that can be used with HuggingFace Transformers at `save_directory`."""
     save_directory = Path(save_directory)


### PR DESCRIPTION
# Overview

This PR adds a colab notebook that walks a user through evaluating our models (or the baselines we compare to) on SentEval.

It is probably not actually feasible to use colab for evaluation as a full run takes >7 hours, but this does provide documentation for how a user would set up the evaluation locally.

Should address #180.