### PR TITLE
Wrong link in license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![build](https://github.com/JohnGiorgi/declutr/workflows/build/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/JohnGiorgi/DeCLUTR/branch/master/graph/badge.svg)](https://codecov.io/gh/JohnGiorgi/DeCLUTR)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
-![GitHub](https://img.shields.io/github/license/JohnGiorgi/allennlp-multi-label-classification?color=blue)
+![GitHub](https://img.shields.io/github/license/JohnGiorgi/DeCLUTR?color=blue)
 
 # DeCLUTR: Deep Contrastive Learning for Unsupervised Textual Representations
 


### PR DESCRIPTION
The link to the license badge in the README had the wrong link. Fixed.