### PR TITLE
Remove Union from all typer type hints

### DIFF
--- a/scripts/preprocess_openwebtext.py
+++ b/scripts/preprocess_openwebtext.py
@@ -2,7 +2,7 @@
 import shutil
 import tarfile
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import typer
 from declutr.common.data_utils import sanitize
@@ -14,7 +14,7 @@ SAVING = "\U0001F4BE"
 MINING = "\U000026CF"
 
 
-def _write_output_to_disk(text: List[str], output_filepath: Union[str, Path]) -> None:
+def _write_output_to_disk(text: List[str], output_filepath: Path) -> None:
     """Writes a list of documents, `text`, to the file `output_filepath`, one document per line."""
     # Create the directory path if it doesn't exist
     output_filepath = Path(output_filepath)
@@ -36,8 +36,8 @@ def _write_output_to_disk(text: List[str], output_filepath: Union[str, Path]) ->
 
 
 def main(
-    openwebtext_path: Union[str, Path],
-    output_filepath: Union[str, Path],
+    openwebtext_path: Path,
+    output_filepath: Path,
     min_length: Optional[int] = None,
     lowercase: bool = True,
     max_documents: Optional[int] = None,

--- a/scripts/preprocess_wikitext_103.py
+++ b/scripts/preprocess_wikitext_103.py
@@ -3,7 +3,7 @@ import io
 import re
 import zipfile
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import requests
 import typer
@@ -17,7 +17,7 @@ SAVING = "\U0001F4BE"
 DOWNLOAD = "\U00002B07"
 
 
-def _write_output_to_disk(text: List[str], output_filepath: Union[str, Path]) -> None:
+def _write_output_to_disk(text: List[str], output_filepath: Path) -> None:
     """Writes a list of documents, `text`, to the file `output_filepath`, one document per line."""
     # Create the directory path if it doesn't exist
     output_filepath = Path(output_filepath)
@@ -39,7 +39,7 @@ def _write_output_to_disk(text: List[str], output_filepath: Union[str, Path]) ->
 
 
 def main(
-    output_filepath: Union[str, Path],
+    output_filepath: Path,
     segment_sentences: bool = False,
     lowercase: bool = False,
     min_length: Optional[int] = None,

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -277,7 +277,7 @@ def compute_aggregate_scores(path_to_results: str, ignore_tasks: List[str] = Non
 def random(
     path_to_senteval: str,
     embedding_dim: int = 512,
-    output_filepath: str = None,
+    output_filepath: Path = None,
     prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
@@ -303,7 +303,7 @@ def random(
 def bow(
     path_to_senteval: str,
     path_to_vectors: str,
-    output_filepath: str = None,
+    output_filepath: Path = None,
     prototyping_config: bool = False,
     verbose: bool = False,
 ) -> None:
@@ -399,7 +399,7 @@ def bow(
 def infersent(
     path_to_senteval: str,
     path_to_vectors: str,
-    output_filepath: str = None,
+    output_filepath: Path = None,
     cuda_device: int = -1,
     prototyping_config: bool = False,
     verbose: bool = False,
@@ -462,7 +462,7 @@ def infersent(
 @app.command()
 def google_use(
     path_to_senteval: str,
-    output_filepath: str = None,
+    output_filepath: Path = None,
     tfhub_model_url: str = None,
     tfhub_cache_dir: str = None,
     prototyping_config: bool = False,
@@ -516,7 +516,7 @@ def google_use(
 def transformers(
     path_to_senteval: str,
     pretrained_model_name_or_path: str,
-    output_filepath: str = None,
+    output_filepath: Path = None,
     mean_pool: bool = False,
     cuda_device: int = -1,
     prototyping_config: bool = False,
@@ -598,7 +598,7 @@ def transformers(
 def sentence_transformers(
     path_to_senteval: str,
     pretrained_model_name_or_path: str,
-    output_filepath: str = None,
+    output_filepath: Path = None,
     cuda_device: int = -1,
     prototyping_config: bool = False,
     verbose: bool = False,
@@ -649,7 +649,7 @@ def sentence_transformers(
 def allennlp(
     path_to_senteval: str,
     path_to_allennlp_archive: str,
-    output_filepath: str = None,
+    output_filepath: Path = None,
     weights_file: str = None,
     cuda_device: int = -1,
     output_dict_field: str = "embeddings",

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -220,7 +220,7 @@ def _run_senteval(
     path_to_senteval: str,
     batcher: Callable,
     prepare: Callable,
-    output_filepath: Union[str, Path] = None,
+    output_filepath: Path = None,
 ) -> None:
     sys.path.insert(0, path_to_senteval)
     import senteval

--- a/scripts/save_pretrained_hf.py
+++ b/scripts/save_pretrained_hf.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import typer
-import Union
 from allennlp.common import util as common_util
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
@@ -12,7 +11,7 @@ SAVING = "\U0001F4BE"
 HUGGING_FACE = "\U0001F917"
 
 
-def main(archive_file: str, save_directory: Union[str, Path]) -> None:
+def main(archive_file: str, save_directory: Path) -> None:
     """Saves the model and tokenizer from an AllenNLP `archive_file` path pointing to a trained
     DeCLUTR model to a format that can be used with HuggingFace Transformers at `save_directory`."""
     save_directory = Path(save_directory)


### PR DESCRIPTION
Previously, some variables in the typer scripts were annotated as `Union[str, Path]`. This use to work without issue, but I guess after a certain typer version the following error is thrown:

```bash
AssertionError: Typer Currently doesn't support Union types
```

Thanks to @kingafy for bringing this to my attention.

This PR replaces all type hints `Union[str, Path]` with `Path` in the scripts. It also changes the `output_filepath` type hint of `run_senteval.py` to `Path` (from `str`).