### PR TITLE
Documentation on exporting to HF Transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ The `--overrides` flag allows you to override any field in the config with a JSO
 
 #### Exporting a trained model to HuggingFace Transformers
 
-We have provided a simple script to export a trained model so that it can be loaded with [Hugging Face Transformers]((https://github.com/huggingface/transformers))
+We have provided a simple script to export a trained model so that it can be loaded with [Hugging Face Transformers](https://github.com/huggingface/transformers)
 
 ```bash
-!wget -nc https://github.com/JohnGiorgi/DeCLUTR/blob/master/scripts/save_pretrained_hf.py
+wget -nc https://github.com/JohnGiorgi/DeCLUTR/blob/master/scripts/save_pretrained_hf.py
 python save_pretrained_hf.py --archive-file "output" --save-directory "output_transformers"
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
+# DeCLUTR: Deep Contrastive Learning for Unsupervised Textual Representations
+
 ![build](https://github.com/JohnGiorgi/declutr/workflows/build/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/JohnGiorgi/DeCLUTR/branch/master/graph/badge.svg)](https://codecov.io/gh/JohnGiorgi/DeCLUTR)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 ![GitHub](https://img.shields.io/github/license/JohnGiorgi/DeCLUTR?color=blue)
-
-# DeCLUTR: Deep Contrastive Learning for Unsupervised Textual Representations
 
 The corresponding code for our paper: [DeCLUTR: Deep Contrastive Learning for Unsupervised Textual Representations](https://arxiv.org/abs/2006.03659). Results on [SentEval](https://github.com/facebookresearch/SentEval) are presented below (as averaged scores on the downstream and probing task test sets), along with existing state-of-the-art methods.
 
@@ -97,7 +97,27 @@ allennlp train "training_config/declutr.jsonnet" \
     --include-package "declutr"
 ```
 
-The `--overrides` flag allows you to override any field in the config with a JSON-formatted string, but you can equivalently update the config itself if you prefer. During training, models, vocabulary, configuration, and log files will be saved to the directory provided by `--serialization-dir`. This can be changed to any directory you like. 
+The `--overrides` flag allows you to override any field in the config with a JSON-formatted string, but you can equivalently update the config itself if you prefer. During training, models, vocabulary, configuration, and log files will be saved to the directory provided by `--serialization-dir`. This can be changed to any directory you like.
+
+#### Exporting a trained model to HuggingFace Transformers
+
+We have provided a simple script to export a trained model so that it can be loaded with [Hugging Face Transformers]((https://github.com/huggingface/transformers))
+
+```bash
+!wget -nc https://github.com/JohnGiorgi/DeCLUTR/blob/master/scripts/save_pretrained_hf.py
+python save_pretrained_hf.py --archive-file "output" --save-directory "output_transformers"
+```
+
+The model, saved to `--save-directory`, can then be loaded using the Hugging Face Transformers library (see [Embedding](#hugging-face-transformers) for more details)
+
+```python
+from transformers import AutoTokenizer, AutoModelForMaskedLM
+  
+tokenizer = AutoTokenizer.from_pretrained("output_transformers")
+model = AutoModel.from_pretrained("output_transformers")
+```
+
+> If you would like to upload your model to the Hugging Face model repository, follow the instructions [here](https://huggingface.co/transformers/model_sharing.html).
 
 #### Multi-GPU training
 
@@ -116,7 +136,7 @@ If your GPU supports it, [mixed-precision](https://devblogs.nvidia.com/mixed-pre
 You can embed text with a trained model in one of three ways:
 
 1. [As a library](#as-a-library): import and initialize an object from this repo, which can be used to embed sentences/paragraphs.
-2. [🤗 Transformers](#🤗-transformers): load our pretrained model with the [🤗 Transformers library](https://github.com/huggingface/transformers).
+2. [Hugging Face Transformers](#hugging-face-transformers): load our pretrained model with the [Hugging Face Transformers library](https://github.com/huggingface/transformers).
 3. [Bulk embed](#bulk-embed-a-file): embed all text in a given text file with a simple command-line interface.
 
 Available pre-trained models:
@@ -157,9 +177,9 @@ See the list of available `PRETRAINED_MODELS` in [declutr/encoder.py](declutr/en
 python -c "from declutr.encoder import PRETRAINED_MODELS ; print(list(PRETRAINED_MODELS.keys()))"
 ```
 
-#### 🤗 Transformers
+#### Hugging Face Transformers
 
-Our pretrained models are also hosted with 🤗 Transformers, so they can be used like any other model in that library. Here is a simple example:
+Our pretrained models are also hosted with Hugging Face Transformers, so they can be used like any other model in that library. Here is a simple example:
 
 ```python
 import torch

--- a/notebooks/embedding.ipynb
+++ b/notebooks/embedding.ipynb
@@ -8,10 +8,11 @@
     },
     "colab": {
       "name": "embedding.ipynb",
-      "provenance": [],
       "private_outputs": true,
+      "provenance": [],
       "collapsed_sections": [],
-      "toc_visible": true
+      "toc_visible": true,
+      "include_colab_link": true
     },
     "accelerator": "GPU"
   },
@@ -19,8 +20,17 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Q1r5eABrxC3z",
+        "id": "view-in-github",
         "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/documentation-on-exporting-to-hf/notebooks/embedding.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Q1r5eABrxC3z"
       },
       "source": [
         "# Embedding text with an existing model\n",
@@ -41,8 +51,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ObkQs5cixC30",
-        "colab_type": "text"
+        "id": "ObkQs5cixC30"
       },
       "source": [
         "## 🔧 Install the prerequisites"
@@ -51,9 +60,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "NNQLlqrtOv5h",
-        "colab_type": "code",
-        "colab": {}
+        "id": "NNQLlqrtOv5h"
       },
       "source": [
         "!pip install git+https://github.com/JohnGiorgi/DeCLUTR.git"
@@ -64,8 +71,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "iV_jB7IZxC4d",
-        "colab_type": "text"
+        "id": "iV_jB7IZxC4d"
       },
       "source": [
         "Finally, let's check to see if we have a GPU available, which we can use to dramatically speed up the embedding of text"
@@ -74,9 +80,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "f5jfZhdRxC4e",
-        "colab_type": "code",
-        "colab": {}
+        "id": "f5jfZhdRxC4e"
       },
       "source": [
         "import torch\n",
@@ -94,8 +98,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "fSVlxjYexC4k",
-        "colab_type": "text"
+        "id": "fSVlxjYexC4k"
       },
       "source": [
         "## 1️⃣ As a library\n",
@@ -106,9 +109,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Q8pG_xeZxC4m",
-        "colab_type": "code",
-        "colab": {}
+        "id": "Q8pG_xeZxC4m"
       },
       "source": [
         "from declutr import Encoder\n",
@@ -133,8 +134,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Wjg7fRX4xC4s",
-        "colab_type": "text"
+        "id": "Wjg7fRX4xC4s"
       },
       "source": [
         "These embeddings can then be used, for example, to compute the semantic similarity between some number of sentences or paragraphs."
@@ -143,9 +143,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "DvZ3ciiqVXBL",
-        "colab_type": "code",
-        "colab": {}
+        "id": "DvZ3ciiqVXBL"
       },
       "source": [
         "from scipy.spatial.distance import cosine\n",
@@ -160,8 +158,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "E-mdfiUzVte-",
-        "colab_type": "text"
+        "id": "E-mdfiUzVte-"
       },
       "source": [
         "Mainly for fun, the following cells visualize the semantic similarity with a heatmap!"
@@ -170,9 +167,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "xsE487dgxC4t",
-        "colab_type": "code",
-        "colab": {}
+        "id": "xsE487dgxC4t"
       },
       "source": [
         "from typing import List\n",
@@ -199,9 +194,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "PSc4u6XbUgPD",
-        "colab_type": "code",
-        "colab": {}
+        "id": "PSc4u6XbUgPD"
       },
       "source": [
         "plot_heatmap(text, embeddings)"
@@ -212,8 +205,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "PAEXMEQ2xC41",
-        "colab_type": "text"
+        "id": "PAEXMEQ2xC41"
       },
       "source": [
         "See the list of available `PRETRAINED_MODELS` in [declutr/encoder.py](https://github.com/JohnGiorgi/DeCLUTR/blob/master/declutr/encoder.py)"
@@ -222,9 +214,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "2imLEDWDxC42",
-        "colab_type": "code",
-        "colab": {}
+        "id": "2imLEDWDxC42"
       },
       "source": [
         "from declutr.encoder import PRETRAINED_MODELS ; print(list(PRETRAINED_MODELS.keys()))"
@@ -235,8 +225,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "r9NudDYNxC46",
-        "colab_type": "text"
+        "id": "r9NudDYNxC46"
       },
       "source": [
         "## 2️⃣ 🤗 Transformers\n",
@@ -247,9 +236,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "6a4Ymv39xC47",
-        "colab_type": "code",
-        "colab": {}
+        "id": "6a4Ymv39xC47"
       },
       "source": [
         "import torch\n",
@@ -294,8 +281,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "QutYGRu9xC5B",
-        "colab_type": "text"
+        "id": "QutYGRu9xC5B"
       },
       "source": [
         "Currently available models:\n",
@@ -307,8 +293,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "QvpLSGecxC5C",
-        "colab_type": "text"
+        "id": "QvpLSGecxC5C"
       },
       "source": [
         "## 3️⃣ Bulk embed a file\n",
@@ -319,9 +304,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "SG4kpaJGxC5C",
-        "colab_type": "code",
-        "colab": {}
+        "id": "SG4kpaJGxC5C"
       },
       "source": [
         "text = [\n",
@@ -340,8 +323,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "mOG-sN2SxC5H",
-        "colab_type": "text"
+        "id": "mOG-sN2SxC5H"
       },
       "source": [
         "We then need a pretrained model to embed the text with. Following our running example, lets use DeCLUTR-small"
@@ -350,9 +332,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "0VoqRh7WxC5J",
-        "colab_type": "code",
-        "colab": {}
+        "id": "0VoqRh7WxC5J"
       },
       "source": [
         "from allennlp.common.file_utils import cached_path\n",
@@ -367,8 +347,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "eBQfez2axC5O",
-        "colab_type": "text"
+        "id": "eBQfez2axC5O"
       },
       "source": [
         "To embed all text in a given file with a trained model, run the following command"
@@ -377,9 +356,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "0wNYDQ7-xC5P",
-        "colab_type": "code",
-        "colab": {}
+        "id": "0wNYDQ7-xC5P"
       },
       "source": [
         "# When embedding text with a pretrained model, we do NOT want to sample spans.\n",
@@ -400,8 +377,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "0u23mh0UxC5W",
-        "colab_type": "text"
+        "id": "0u23mh0UxC5W"
       },
       "source": [
         "As a sanity check, lets load the embeddings and make sure their cosine similarity is as expected"
@@ -410,9 +386,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "NGYcpU3DxC5X",
-        "colab_type": "code",
-        "colab": {}
+        "id": "NGYcpU3DxC5X"
       },
       "source": [
         "import json\n",
@@ -428,9 +402,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "OrsptLBmxC5d",
-        "colab_type": "code",
-        "colab": {}
+        "id": "OrsptLBmxC5d"
       },
       "source": [
         "from scipy.spatial.distance import cosine\n",
@@ -444,8 +416,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "0mswpdqCxC5i",
-        "colab_type": "text"
+        "id": "0mswpdqCxC5i"
       },
       "source": [
         "## ♻️ Conclusion\n",

--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -1,285 +1,284 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "I8jt6ML03DS5"
-   },
-   "source": [
-    "# Training your own model\n",
-    "\n",
-    "This notebook will walk you through training your own model using [DeCLUTR](https://github.com/JohnGiorgi/DeCLUTR)."
-   ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "name": "training.ipynb",
+      "private_outputs": true,
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true,
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.8.5"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "SU3Iod2-g0-o"
-   },
-   "source": [
-    "## 🔧 Install the prerequisites"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "sr4r5pN40Kli"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install git+https://github.com/JohnGiorgi/DeCLUTR.git"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Zog7ApwuUD7_"
-   },
-   "source": [
-    "## 📖 Preparing a dataset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "uwnLpUmN4Art"
-   },
-   "source": [
-    "\n",
-    "A dataset is simply a file containing one item of text (a document, a scientific paper, etc.) per line. For demonstration purposes, we have provided a script that will download the [WikiText-103](https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/) dataset and format it for training with our method.\n",
-    "\n",
-    "The only \"gotcha\" is that each piece of text needs to be long enough so that we can sample spans from it. In general, you should collect documents of a minimum length according to the following:\n",
-    "\n",
-    "```python\n",
-    "min_length = num_anchors * max_span_len * 2\n",
-    "```\n",
-    "\n",
-    "In our paper, we set `num_anchors=2` and `max_span_len=512`, so we require documents of `min_length=2048`. We simply need to provide this value as an argument when running the script:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "q0fwnwq23aAZ"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "train_data_path = \"wikitext_103/train.txt\"\n",
-    "min_length = 2048\n",
-    "\n",
-    "!wget -nc https://raw.githubusercontent.com/JohnGiorgi/DeCLUTR/master/scripts/preprocess_wikitext_103.py\n",
-    "!python preprocess_wikitext_103.py $train_data_path --min-length $min_length"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yUEFeupP6qy-"
-   },
-   "source": [
-    "Lets confirm that our dataset looks as expected."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "K7ffGXCn7Cpq"
-   },
-   "outputs": [],
-   "source": [
-    "!wc -l $train_data_path  # This should be approximately 17.8K lines"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "10DprWZc9iV6"
-   },
-   "outputs": [],
-   "source": [
-    "!head -n 1 $train_data_path  # This should be a single Wikipedia entry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "VKYdambZ59nM"
-   },
-   "source": [
-    "## 🏃 Training the model\n",
-    "\n",
-    "Once you have collected the dataset, you can easily initiate a training session with the `allennlp train` command. An experiment is configured using a [Jsonnet](https://jsonnet.org/) config file. Lets take a look at the config for the DeCLUTR-small model presented in [our paper](https://arxiv.org/abs/2006.03659):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "xTaSExh4ba8e"
-   },
-   "outputs": [],
-   "source": [
-    "!wget -nc https://raw.githubusercontent.com/JohnGiorgi/DeCLUTR/master/training_config/declutr_small.jsonnet\n",
-    "with open(\"declutr_small.jsonnet\", \"r\") as f:\n",
-    "    print(f.read())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "-f1HqWSscWOx"
-   },
-   "source": [
-    "\n",
-    "The only thing to configure is the path to the training set (`train_data_path`), which can be passed to `allennlp train` via the `--overrides` argument (but you can also provide it in your config file directly, if you prefer):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "YS9VuxESBcr3"
-   },
-   "outputs": [],
-   "source": [
-    "overrides = (\n",
-    "    f\"{{'train_data_path': '{train_data_path}', \"\n",
-    "    # lower the batch size to be able to train on Colab GPUs\n",
-    "    f\"'data_loader.batch_size': 2, \"\n",
-    "    # training examples / batch size. Not required, but gives us a more informative progress bar during training\n",
-    "    f\"'data_loader.batches_per_epoch': 8912}}\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Db_cNfZ76KRf"
-   },
-   "outputs": [],
-   "source": [
-    "!allennlp train \"declutr_small.jsonnet\" \\\n",
-    "    --serialization-dir \"output\" \\\n",
-    "    --overrides \"$overrides\" \\\n",
-    "    --include-package \"declutr\" \\\n",
-    "    -f"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Exporting a trained model to HuggingFace Transformers\n",
-    "\n",
-    "We have provided a simple script to export a trained model so that it can be loaded with [Hugging Face Transformers](https://github.com/huggingface/transformers)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!wget -nc https://github.com/JohnGiorgi/DeCLUTR/blob/master/scripts/save_pretrained_hf.py\n",
-    "!python save_pretrained_hf.py --archive-file \"output\" --save-directory \"output_transformers\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The model, saved to `--save-directory`, can then be loaded using the Hugging Face Transformers library\n",
-    "\n",
-    "> See the [embedding notebook](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/embedding.ipynb) for more details on using trained models."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from transformers import AutoTokenizer, AutoModelForMaskedLM\n",
-    "  \n",
-    "tokenizer = AutoTokenizer.from_pretrained(\"output_transformers\")\n",
-    "model = AutoModel.from_pretrained(\"output_transformers\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "> If you would like to upload your model to the Hugging Face model repository, follow the instructions [here](https://huggingface.co/transformers/model_sharing.html)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "eD5dZo18EE-S"
-   },
-   "source": [
-    "## ♻️ Conclusion\n",
-    "\n",
-    "That's it! In this notebook, we covered how to collect data for training the model, and specifically how _long_ that text needs to be. We then briefly covered configuring and running a training session. Please see [our paper](https://arxiv.org/abs/2006.03659) and [repo](https://github.com/JohnGiorgi/DeCLUTR) for more details, and don't hesitate to open an issue if you have any trouble!"
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "collapsed_sections": [],
-   "name": "training.ipynb",
-   "private_outputs": true,
-   "provenance": [],
-   "toc_visible": true
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/documentation-on-exporting-to-hf/notebooks/training.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "I8jt6ML03DS5"
+      },
+      "source": [
+        "# Training your own model\n",
+        "\n",
+        "This notebook will walk you through training your own model using [DeCLUTR](https://github.com/JohnGiorgi/DeCLUTR)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SU3Iod2-g0-o"
+      },
+      "source": [
+        "## 🔧 Install the prerequisites"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "sr4r5pN40Kli"
+      },
+      "source": [
+        "!pip install git+https://github.com/JohnGiorgi/DeCLUTR.git"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Zog7ApwuUD7_"
+      },
+      "source": [
+        "## 📖 Preparing a dataset"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "uwnLpUmN4Art"
+      },
+      "source": [
+        "\n",
+        "A dataset is simply a file containing one item of text (a document, a scientific paper, etc.) per line. For demonstration purposes, we have provided a script that will download the [WikiText-103](https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/) dataset and format it for training with our method.\n",
+        "\n",
+        "The only \"gotcha\" is that each piece of text needs to be long enough so that we can sample spans from it. In general, you should collect documents of a minimum length according to the following:\n",
+        "\n",
+        "```python\n",
+        "min_length = num_anchors * max_span_len * 2\n",
+        "```\n",
+        "\n",
+        "In our paper, we set `num_anchors=2` and `max_span_len=512`, so we require documents of `min_length=2048`. We simply need to provide this value as an argument when running the script:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "q0fwnwq23aAZ"
+      },
+      "source": [
+        "import os\n",
+        "\n",
+        "train_data_path = \"wikitext_103/train.txt\"\n",
+        "min_length = 2048\n",
+        "\n",
+        "!wget -nc https://raw.githubusercontent.com/JohnGiorgi/DeCLUTR/master/scripts/preprocess_wikitext_103.py\n",
+        "!python preprocess_wikitext_103.py $train_data_path --min-length $min_length"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yUEFeupP6qy-"
+      },
+      "source": [
+        "Lets confirm that our dataset looks as expected."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "K7ffGXCn7Cpq"
+      },
+      "source": [
+        "!wc -l $train_data_path  # This should be approximately 17.8K lines"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "10DprWZc9iV6"
+      },
+      "source": [
+        "!head -n 1 $train_data_path  # This should be a single Wikipedia entry"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VKYdambZ59nM"
+      },
+      "source": [
+        "## 🏃 Training the model\n",
+        "\n",
+        "Once you have collected the dataset, you can easily initiate a training session with the `allennlp train` command. An experiment is configured using a [Jsonnet](https://jsonnet.org/) config file. Lets take a look at the config for the DeCLUTR-small model presented in [our paper](https://arxiv.org/abs/2006.03659):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "xTaSExh4ba8e"
+      },
+      "source": [
+        "!wget -nc https://raw.githubusercontent.com/JohnGiorgi/DeCLUTR/master/training_config/declutr_small.jsonnet\n",
+        "with open(\"declutr_small.jsonnet\", \"r\") as f:\n",
+        "    print(f.read())"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-f1HqWSscWOx"
+      },
+      "source": [
+        "\n",
+        "The only thing to configure is the path to the training set (`train_data_path`), which can be passed to `allennlp train` via the `--overrides` argument (but you can also provide it in your config file directly, if you prefer):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "YS9VuxESBcr3"
+      },
+      "source": [
+        "overrides = (\n",
+        "    f\"{{'train_data_path': '{train_data_path}', \"\n",
+        "    # lower the batch size to be able to train on Colab GPUs\n",
+        "    \"'data_loader.batch_size': 2, \"\n",
+        "    # training examples / batch size. Not required, but gives us a more informative progress bar during training\n",
+        "    \"'data_loader.batches_per_epoch': 8912}}\"\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Db_cNfZ76KRf"
+      },
+      "source": [
+        "!allennlp train \"declutr_small.jsonnet\" \\\n",
+        "    --serialization-dir \"output\" \\\n",
+        "    --overrides \"$overrides\" \\\n",
+        "    --include-package \"declutr\" \\\n",
+        "    -f"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Qsbr6OMv16GQ"
+      },
+      "source": [
+        "### 🤗 Exporting a trained model to HuggingFace Transformers\n",
+        "\n",
+        "We have provided a simple script to export a trained model so that it can be loaded with [Hugging Face Transformers](https://github.com/huggingface/transformers)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "KqmWVD0y16GQ"
+      },
+      "source": [
+        "!wget -nc https://github.com/JohnGiorgi/DeCLUTR/blob/master/scripts/save_pretrained_hf.py\n",
+        "!python save_pretrained_hf.py --archive-file \"output\" --save-directory \"output_transformers\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "N0-NTFaH16GQ"
+      },
+      "source": [
+        "The model, saved to `--save-directory`, can then be loaded using the Hugging Face Transformers library\n",
+        "\n",
+        "> See the [embedding notebook](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/embedding.ipynb) for more details on using trained models."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "pAl1zIya16GQ"
+      },
+      "source": [
+        "from transformers import AutoTokenizer, AutoModelForMaskedLM\n",
+        "  \n",
+        "tokenizer = AutoTokenizer.from_pretrained(\"output_transformers\")\n",
+        "model = AutoModel.from_pretrained(\"output_transformers\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "mzQ0G4rp16GQ"
+      },
+      "source": [
+        "> If you would like to upload your model to the Hugging Face model repository, follow the instructions [here](https://huggingface.co/transformers/model_sharing.html)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eD5dZo18EE-S"
+      },
+      "source": [
+        "## ♻️ Conclusion\n",
+        "\n",
+        "That's it! In this notebook, we covered how to collect data for training the model, and specifically how _long_ that text needs to be. We then briefly covered configuring and running a training session. Please see [our paper](https://arxiv.org/abs/2006.03659) and [repo](https://github.com/JohnGiorgi/DeCLUTR) for more details, and don't hesitate to open an issue if you have any trouble!"
+      ]
+    }
+  ]
 }

--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -218,7 +218,7 @@
    "source": [
     "The model, saved to `--save-directory`, can then be loaded using the Hugging Face Transformers library\n",
     "\n",
-    "> See the [embedding notebook](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/embedding.ipynb) for more details on using trained models"
+    "> See the [embedding notebook](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/embedding.ipynb) for more details on using trained models."
    ]
   },
   {
@@ -231,6 +231,13 @@
     "  \n",
     "tokenizer = AutoTokenizer.from_pretrained(\"output_transformers\")\n",
     "model = AutoModel.from_pretrained(\"output_transformers\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> If you would like to upload your model to the Hugging Face model repository, follow the instructions [here](https://huggingface.co/transformers/model_sharing.html)."
    ]
   },
   {

--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -1,225 +1,278 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "training.ipynb",
-      "provenance": [],
-      "private_outputs": true,
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "I8jt6ML03DS5"
+   },
+   "source": [
+    "# Training your own model\n",
+    "\n",
+    "This notebook will walk you through training your own model using [DeCLUTR](https://github.com/JohnGiorgi/DeCLUTR)."
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "I8jt6ML03DS5"
-      },
-      "source": [
-        "# Training your own model\n",
-        "\n",
-        "This notebook will walk you through training your own model using [DeCLUTR](https://github.com/JohnGiorgi/DeCLUTR)."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "SU3Iod2-g0-o"
-      },
-      "source": [
-        "## 🔧 Install the prerequisites"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "sr4r5pN40Kli",
-        "colab": {}
-      },
-      "source": [
-        "!pip install git+https://github.com/JohnGiorgi/DeCLUTR.git"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "Zog7ApwuUD7_"
-      },
-      "source": [
-        "## 📖 Preparing a dataset"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "uwnLpUmN4Art"
-      },
-      "source": [
-        "\n",
-        "A dataset is simply a file containing one item of text (a document, a scientific paper, etc.) per line. For demonstration purposes, we have provided a script that will download the [WikiText-103](https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/) dataset and format it for training with our method.\n",
-        "\n",
-        "The only \"gotcha\" is that each piece of text needs to be long enough so that we can sample spans from it. In general, you should collect documents of a minimum length according to the following:\n",
-        "\n",
-        "```python\n",
-        "min_length = num_anchors * max_span_len * 2\n",
-        "```\n",
-        "\n",
-        "In our paper, we set `num_anchors=2` and `max_span_len=512`, so we require documents of `min_length=2048`. We simply need to provide this value as an argument when running the script:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "q0fwnwq23aAZ",
-        "colab": {}
-      },
-      "source": [
-        "import os\n",
-        "\n",
-        "train_data_path = \"wikitext_103/train.txt\"\n",
-        "min_length = 2048\n",
-        "\n",
-        "!wget -nc https://raw.githubusercontent.com/JohnGiorgi/DeCLUTR/master/scripts/preprocess_wikitext_103.py\n",
-        "!python preprocess_wikitext_103.py $train_data_path --min-length $min_length"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "yUEFeupP6qy-"
-      },
-      "source": [
-        "Lets confirm that our dataset looks as expected."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "K7ffGXCn7Cpq",
-        "colab": {}
-      },
-      "source": [
-        "!wc -l $train_data_path  # This should be approximately 17.8K lines"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "10DprWZc9iV6",
-        "colab": {}
-      },
-      "source": [
-        "!head -n 1 $train_data_path  # This should be a single Wikipedia entry"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "VKYdambZ59nM"
-      },
-      "source": [
-        "## 🏃 Training the model\n",
-        "\n",
-        "Once you have collected the dataset, you can easily initiate a training session with the `allennlp train` command. An experiment is configured using a [Jsonnet](https://jsonnet.org/) config file. Lets take a look at the config for the DeCLUTR-small model presented in [our paper](https://arxiv.org/abs/2006.03659):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "xTaSExh4ba8e",
-        "colab": {}
-      },
-      "source": [
-        "!wget -nc https://raw.githubusercontent.com/JohnGiorgi/DeCLUTR/master/training_config/declutr_small.jsonnet\n",
-        "with open(\"declutr_small.jsonnet\", \"r\") as f:\n",
-        "    print(f.read())"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "-f1HqWSscWOx"
-      },
-      "source": [
-        "\n",
-        "The only thing to configure is the path to the training set (`train_data_path`), which can be passed to `allennlp train` via the `--overrides` argument (but you can also provide it in your config file directly, if you prefer):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "YS9VuxESBcr3",
-        "colab": {}
-      },
-      "source": [
-        "overrides = (\n",
-        "    f\"{{'train_data_path': '{train_data_path}', \"\n",
-        "    # lower the batch size to be able to train on Colab GPUs\n",
-        "    f\"'data_loader.batch_size': 2, \"\n",
-        "    # training examples / batch size. Not required, but gives us a more informative progress bar during training\n",
-        "    f\"'data_loader.batches_per_epoch': 8912}}\"\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "Db_cNfZ76KRf",
-        "colab": {}
-      },
-      "source": [
-        "!allennlp train \"declutr_small.jsonnet\" \\\n",
-        "    --serialization-dir \"output\" \\\n",
-        "    --overrides \"$overrides\" \\\n",
-        "    --include-package \"declutr\" \\\n",
-        "    -f"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "eD5dZo18EE-S"
-      },
-      "source": [
-        "## ♻️ Conclusion\n",
-        "\n",
-        "That's it! In this notebook, we covered how to collect data for training the model, and specifically how _long_ that text needs to be. We then briefly covered configuring and running a training session. Please see [our paper](https://arxiv.org/abs/2006.03659) and [repo](https://github.com/JohnGiorgi/DeCLUTR) for more details, and don't hesitate to open an issue if you have any trouble!"
-      ]
-    }
-  ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "SU3Iod2-g0-o"
+   },
+   "source": [
+    "## 🔧 Install the prerequisites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "sr4r5pN40Kli"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install git+https://github.com/JohnGiorgi/DeCLUTR.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Zog7ApwuUD7_"
+   },
+   "source": [
+    "## 📖 Preparing a dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "uwnLpUmN4Art"
+   },
+   "source": [
+    "\n",
+    "A dataset is simply a file containing one item of text (a document, a scientific paper, etc.) per line. For demonstration purposes, we have provided a script that will download the [WikiText-103](https://www.salesforce.com/products/einstein/ai-research/the-wikitext-dependency-language-modeling-dataset/) dataset and format it for training with our method.\n",
+    "\n",
+    "The only \"gotcha\" is that each piece of text needs to be long enough so that we can sample spans from it. In general, you should collect documents of a minimum length according to the following:\n",
+    "\n",
+    "```python\n",
+    "min_length = num_anchors * max_span_len * 2\n",
+    "```\n",
+    "\n",
+    "In our paper, we set `num_anchors=2` and `max_span_len=512`, so we require documents of `min_length=2048`. We simply need to provide this value as an argument when running the script:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "q0fwnwq23aAZ"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "train_data_path = \"wikitext_103/train.txt\"\n",
+    "min_length = 2048\n",
+    "\n",
+    "!wget -nc https://raw.githubusercontent.com/JohnGiorgi/DeCLUTR/master/scripts/preprocess_wikitext_103.py\n",
+    "!python preprocess_wikitext_103.py $train_data_path --min-length $min_length"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yUEFeupP6qy-"
+   },
+   "source": [
+    "Lets confirm that our dataset looks as expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "K7ffGXCn7Cpq"
+   },
+   "outputs": [],
+   "source": [
+    "!wc -l $train_data_path  # This should be approximately 17.8K lines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "10DprWZc9iV6"
+   },
+   "outputs": [],
+   "source": [
+    "!head -n 1 $train_data_path  # This should be a single Wikipedia entry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "VKYdambZ59nM"
+   },
+   "source": [
+    "## 🏃 Training the model\n",
+    "\n",
+    "Once you have collected the dataset, you can easily initiate a training session with the `allennlp train` command. An experiment is configured using a [Jsonnet](https://jsonnet.org/) config file. Lets take a look at the config for the DeCLUTR-small model presented in [our paper](https://arxiv.org/abs/2006.03659):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "xTaSExh4ba8e"
+   },
+   "outputs": [],
+   "source": [
+    "!wget -nc https://raw.githubusercontent.com/JohnGiorgi/DeCLUTR/master/training_config/declutr_small.jsonnet\n",
+    "with open(\"declutr_small.jsonnet\", \"r\") as f:\n",
+    "    print(f.read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "-f1HqWSscWOx"
+   },
+   "source": [
+    "\n",
+    "The only thing to configure is the path to the training set (`train_data_path`), which can be passed to `allennlp train` via the `--overrides` argument (but you can also provide it in your config file directly, if you prefer):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "YS9VuxESBcr3"
+   },
+   "outputs": [],
+   "source": [
+    "overrides = (\n",
+    "    f\"{{'train_data_path': '{train_data_path}', \"\n",
+    "    # lower the batch size to be able to train on Colab GPUs\n",
+    "    f\"'data_loader.batch_size': 2, \"\n",
+    "    # training examples / batch size. Not required, but gives us a more informative progress bar during training\n",
+    "    f\"'data_loader.batches_per_epoch': 8912}}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Db_cNfZ76KRf"
+   },
+   "outputs": [],
+   "source": [
+    "!allennlp train \"declutr_small.jsonnet\" \\\n",
+    "    --serialization-dir \"output\" \\\n",
+    "    --overrides \"$overrides\" \\\n",
+    "    --include-package \"declutr\" \\\n",
+    "    -f"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Exporting a trained model to HuggingFace Transformers\n",
+    "\n",
+    "We have provided a simple script to export a trained model so that it can be loaded with [Hugging Face Transformers](https://github.com/huggingface/transformers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!wget -nc https://github.com/JohnGiorgi/DeCLUTR/blob/master/scripts/save_pretrained_hf.py\n",
+    "!python save_pretrained_hf.py --archive-file \"output\" --save-directory \"output_transformers\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The model, saved to `--save-directory`, can then be loaded using the Hugging Face Transformers library\n",
+    "\n",
+    "> See the [embedding notebook](https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/master/notebooks/embedding.ipynb) for more details on using trained models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer, AutoModelForMaskedLM\n",
+    "  \n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"output_transformers\")\n",
+    "model = AutoModel.from_pretrained(\"output_transformers\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "eD5dZo18EE-S"
+   },
+   "source": [
+    "## ♻️ Conclusion\n",
+    "\n",
+    "That's it! In this notebook, we covered how to collect data for training the model, and specifically how _long_ that text needs to be. We then briefly covered configuring and running a training session. Please see [our paper](https://arxiv.org/abs/2006.03659) and [repo](https://github.com/JohnGiorgi/DeCLUTR) for more details, and don't hesitate to open an issue if you have any trouble!"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "training.ipynb",
+   "private_outputs": true,
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Based on #205, I have added documentation that explains how you would export a model trained with our repo so that it can be loaded with [Hugging Face Transformers](https://github.com/huggingface/transformers).

Closes #205.