### PR TITLE
Cleaner regex in configs

### DIFF
--- a/training_config/contrastive_only.jsonnet
+++ b/training_config/contrastive_only.jsonnet
@@ -61,12 +61,10 @@ local min_length = 32;
             "lr": 5e-5,
             "eps": 1e-06,
             "correct_bias": false,
-            "weight_decay": 0.0,
+            "weight_decay": 0.1,
             "parameter_groups": [
-                # Apply weight decay to pre-trained params, excluding LayerNorm params and biases
-                # See: https://github.com/huggingface/transformers/blob/2184f87003c18ad8a172ecab9a821626522cf8e7/examples/run_ner.py#L105
-                # Regex: https://regex101.com/r/ZUyDgR/3/tests
-                [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.1}],
+                // Apply weight decay to pre-trained params, excluding LayerNorm params and biases
+                [["bias", "LayerNorm\\.weight", "layer_norm\\.weight"], {"weight_decay": 0}],
             ],
         },
         "num_epochs": 1,

--- a/training_config/declutr.jsonnet
+++ b/training_config/declutr.jsonnet
@@ -61,12 +61,10 @@ local min_length = 32;
             "lr": 5e-5,
             "eps": 1e-06,
             "correct_bias": false,
-            "weight_decay": 0.0,
+            "weight_decay": 0.1,
             "parameter_groups": [
                 // Apply weight decay to pre-trained params, excluding LayerNorm params and biases
-                // See: https://github.com/huggingface/transformers/blob/2184f87003c18ad8a172ecab9a821626522cf8e7/examples/run_ner.py#L105
-                // Regex: https://regex101.com/r/ZUyDgR/3/tests
-                [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.1}],
+                [["bias", "LayerNorm\\.weight", "layer_norm\\.weight"], {"weight_decay": 0}],
             ],
         },
         "num_epochs": 1,

--- a/training_config/declutr_base.jsonnet
+++ b/training_config/declutr_base.jsonnet
@@ -61,12 +61,10 @@ local min_length = 32;
             "lr": 5e-5,
             "eps": 1e-06,
             "correct_bias": false,
-            "weight_decay": 0.0,
+            "weight_decay": 0.1,
             "parameter_groups": [
                 // Apply weight decay to pre-trained params, excluding LayerNorm params and biases
-                // See: https://github.com/huggingface/transformers/blob/2184f87003c18ad8a172ecab9a821626522cf8e7/examples/run_ner.py#L105
-                // Regex: https://regex101.com/r/ZUyDgR/3/tests
-                [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.1}],
+                [["bias", "LayerNorm\\.weight", "layer_norm\\.weight"], {"weight_decay": 0}],
             ],
         },
         "num_epochs": 1,

--- a/training_config/declutr_small.jsonnet
+++ b/training_config/declutr_small.jsonnet
@@ -61,12 +61,10 @@ local min_length = 32;
             "lr": 5e-5,
             "eps": 1e-06,
             "correct_bias": false,
-            "weight_decay": 0.0,
+            "weight_decay": 0.1,
             "parameter_groups": [
                 // Apply weight decay to pre-trained params, excluding LayerNorm params and biases
-                // See: https://github.com/huggingface/transformers/blob/2184f87003c18ad8a172ecab9a821626522cf8e7/examples/run_ner.py#L105
-                // Regex: https://regex101.com/r/ZUyDgR/3/tests
-                [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.1}],
+                [["bias", "LayerNorm\\.weight", "layer_norm\\.weight"], {"weight_decay": 0}],
             ],
         },
         "num_epochs": 1,

--- a/training_config/mlm_only.jsonnet
+++ b/training_config/mlm_only.jsonnet
@@ -60,12 +60,10 @@ local min_length = 32;
             "lr": 5e-5,
             "eps": 1e-06,
             "correct_bias": false,
-            "weight_decay": 0.0,
+            "weight_decay": 0.1,
             "parameter_groups": [
-                # Apply weight decay to pre-trained params, excluding LayerNorm params and biases
-                # See: https://github.com/huggingface/transformers/blob/2184f87003c18ad8a172ecab9a821626522cf8e7/examples/run_ner.py#L105
-                # Regex: https://regex101.com/r/ZUyDgR/3/tests
-                [["(?=.*transformer_model)(?=.*\\.+)(?!.*(LayerNorm|bias)).*$"], {"weight_decay": 0.1}],
+                // Apply weight decay to pre-trained params, excluding LayerNorm params and biases
+                [["bias", "LayerNorm\\.weight", "layer_norm\\.weight"], {"weight_decay": 0}],
             ],
         },
         "num_epochs": 1,


### PR DESCRIPTION
A tiny PR that just cleans up the regex used to set the weight decay to 0 for all bias and layernorm parameters. I got this cleaner regex straight from AllenNLP models.