### PR TITLE
Fix issue with overrides string

### DIFF
--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -7,9 +7,7 @@
       "name": "training.ipynb",
       "private_outputs": true,
       "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true,
-      "include_colab_link": true
+      "collapsed_sections": []
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -30,16 +28,6 @@
     }
   },
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/JohnGiorgi/DeCLUTR/blob/documentation-on-exporting-to-hf/notebooks/training.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
-    },
     {
       "cell_type": "markdown",
       "metadata": {
@@ -191,8 +179,19 @@
         "    # lower the batch size to be able to train on Colab GPUs\n",
         "    \"'data_loader.batch_size': 2, \"\n",
         "    # training examples / batch size. Not required, but gives us a more informative progress bar during training\n",
-        "    \"'data_loader.batches_per_epoch': 8912}}\"\n",
+        "    \"'data_loader.batches_per_epoch': 8912}\"\n",
         ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "2v4tiiXgBC2M"
+      },
+      "source": [
+        "overrides"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Fix an issue with the training notebook. `overrides` had an extra `}`.

Closes #218.