### PR TITLE
Add scale fix arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ allennlp train "training_config/declutr.jsonnet" \
 
 The `--overrides` flag allows you to override any field in the config with a JSON-formatted string, but you can equivalently update the config itself if you prefer. During training, models, vocabulary, configuration, and log files will be saved to the directory provided by `--serialization-dir`. This can be changed to any directory you like.
 
+#### Gotchas
+
+- There was a small bug in the original implementation that caused gradients derived from the contrastive loss to be scaled by 1/N, where N is the number of GPUs used during training. This has been fixed. To reproduce results from the paper, set `model.scale_fix` to `False` in your config. Note that this will have no effect if you are not using distributed training with more than 1 GPU.
+
 #### Exporting a trained model to HuggingFace Transformers
 
 We have provided a simple script to export a trained model so that it can be loaded with [Hugging Face Transformers](https://github.com/huggingface/transformers)

--- a/scripts/run_senteval.py
+++ b/scripts/run_senteval.py
@@ -245,7 +245,7 @@ def _run_senteval(
         output_filepath.parents[0].mkdir(parents=True, exist_ok=True)
         with open(output_filepath, "w") as fp:
             # Convert anything that can't be serialized to JSON to a python type
-            json_safe_results = common_util.sanitize_text(results)
+            json_safe_results = common_util.sanitize(results)
             # Add aggregate scores to results dict
             json_safe_results[AGGREGATE_SCORES_KEY] = aggregate_scores
             json.dump(json_safe_results, fp, indent=2)
@@ -544,7 +544,7 @@ def transformers(
         # Place all input tensors on same device as the model
         inputs = {name: tensor.to(params.device) for name, tensor in inputs.items()}
 
-        sequence_output, pooled_output = model(**inputs)
+        sequence_output, pooled_output = model(**inputs)[:2]
 
         # If mean_pool, we take the average of the token-level embeddings, accounting for pads.
         # Otherwise, we take the pooled output for this specific model, which is typically the

--- a/tests/common/test_model_utils.py
+++ b/tests/common/test_model_utils.py
@@ -59,8 +59,7 @@ class TestModelUtils:
             assert torch.equal(tensor, four_dim_input["tokens"][name])
 
     def test_all_gather_anchor_positive_pairs_no_op(self) -> None:
-        """Check that `all_gather_anchor_positive_pairs` is a no-op when not in distributed mode.
-        """
+        """Check that `all_gather_anchor_positive_pairs` is a no-op when not in distributed mode."""
         num_anchors = 2
         num_positives = 2
         batch_size = 16

--- a/training_config/contrastive_only.jsonnet
+++ b/training_config/contrastive_only.jsonnet
@@ -47,6 +47,12 @@ local min_length = 32;
             "type": "nt_xent",
             "temperature": 0.05,
         },
+        // There was a small bug in the original implementation that caused gradients derived from
+        // the contrastive loss to be scaled by 1/N, where N is the number of GPUs used during
+        // training. This has been fixed. To reproduce results from the paper, set this to false.
+        // Note that this will have no effect if you are not using distributed training with more
+        // than 1 GPU.
+        "scale_fix": false
     },
     "data_loader": {
         "batch_size": 4,

--- a/training_config/declutr.jsonnet
+++ b/training_config/declutr.jsonnet
@@ -47,6 +47,12 @@ local min_length = 32;
             "type": "nt_xent",
             "temperature": 0.05,
         },
+        // There was a small bug in the original implementation that caused gradients derived from
+        // the contrastive loss to be scaled by 1/N, where N is the number of GPUs used during
+        // training. This has been fixed. To reproduce results from the paper, set this to false.
+        // Note that this will have no effect if you are not using distributed training with more
+        // than 1 GPU.
+        "scale_fix": false
     },
     "data_loader": {
         "batch_size": 4,

--- a/training_config/declutr_base.jsonnet
+++ b/training_config/declutr_base.jsonnet
@@ -47,6 +47,12 @@ local min_length = 32;
             "type": "nt_xent",
             "temperature": 0.05,
         },
+        // There was a small bug in the original implementation that caused gradients derived from
+        // the contrastive loss to be scaled by 1/N, where N is the number of GPUs used during
+        // training. This has been fixed. To reproduce results from the paper, set this to false.
+        // Note that this will have no effect if you are not using distributed training with more
+        // than 1 GPU.
+        "scale_fix": false
     },
     "data_loader": {
         "batch_size": 4,

--- a/training_config/declutr_small.jsonnet
+++ b/training_config/declutr_small.jsonnet
@@ -47,6 +47,12 @@ local min_length = 32;
             "type": "nt_xent",
             "temperature": 0.05,
         },
+        // There was a small bug in the original implementation that caused gradients derived from
+        // the contrastive loss to be scaled by 1/N, where N is the number of GPUs used during
+        // training. This has been fixed. To reproduce results from the paper, set this to false.
+        // Note that this will have no effect if you are not using distributed training with more
+        // than 1 GPU.
+        "scale_fix": false
     },
     "data_loader": {
         "batch_size": 4,

--- a/training_config/mlm_only.jsonnet
+++ b/training_config/mlm_only.jsonnet
@@ -46,6 +46,12 @@ local min_length = 32;
                 },
             },
         },
+        // There was a small bug in the original implementation that caused gradients derived from
+        // the contrastive loss to be scaled by 1/N, where N is the number of GPUs used during
+        // training. This has been fixed. To reproduce results from the paper, set this to false.
+        // Note that this will have no effect if you are not using distributed training with more
+        // than 1 GPU.
+        "scale_fix": false
     },
     "data_loader": {
         "batch_size": 4,


### PR DESCRIPTION
Following up on the previous PR, this adds a `scale_fix` arg to the model so that it can be turned on or off. By default, it is on. But the provided configs turn it off in order to be comparable to the results from our paper. The argument is explained in the readme.